### PR TITLE
Start from PENDING status to avoid keeping node in FAILED/WAITING

### DIFF
--- a/lib/node/node.js
+++ b/lib/node/node.js
@@ -143,7 +143,7 @@ Node.prototype.setStatusFromInputNodes = function() {
         }
 
         return shouldCacheNode ? STATUS.PENDING : STATUS.READY;
-    }, this.status);
+    }, STATUS.PENDING);
 };
 
 Node.prototype.getInputNodes = function() {


### PR DESCRIPTION
If node was already in failed status it could be because a input node
was in failed status before, so we want to evaluate again that
situation.