### PR TITLE
Fix ready status

### DIFF
--- a/lib/service/database.js
+++ b/lib/service/database.js
@@ -275,14 +275,8 @@ DatabaseService.prototype.queueAnalysisOperations = function(analysis, callback)
 
         // we want to mark all nodes updated_at to NOW() and status to pending before doing any work on them
         nodesToQueueForUpdate.forEach(function(nodeToUpdate) {
-            var status = nodeToUpdate.getInputNodes().reduce(function(_status, inputNode) {
-                if (inputNode.getStatus() === Node.STATUS.PENDING) {
-                    return Node.STATUS.WAITING;
-                }
-                return _status;
-            }, Node.STATUS.PENDING);
-            asyncQueries.push(updateNodeAtAnalysisCatalogQuery(nodeToUpdate.id(), status));
-            nodeToUpdate.setStatus(status);
+            nodeToUpdate.setStatusFromInputNodes();
+            asyncQueries.push(updateNodeAtAnalysisCatalogQuery(nodeToUpdate.id(), nodeToUpdate.getStatus()));
         });
 
         nodesToQueueForUpdate.forEach(function(nodeToUpdate) {

--- a/lib/service/database.js
+++ b/lib/service/database.js
@@ -212,8 +212,11 @@ DatabaseService.prototype.queueAnalysisOperations = function(analysis, callback)
 
     var sortedNodes = analysis.getSortedNodes();
     var sortedNodesIds = sortedNodes.map(function(node) { return node.id(); });
-    var nodesById = sortedNodes.reduce(function(byId, node) {
-        byId[node.id()] = node;
+    var nodesById = analysis.getNodes().reduce(function(byId, node) {
+        if (!byId.hasOwnProperty(node.id())) {
+            byId[node.id()] = [];
+        }
+        byId[node.id()].push(node);
         return byId;
     }, {});
     var query = [
@@ -234,10 +237,12 @@ DatabaseService.prototype.queueAnalysisOperations = function(analysis, callback)
         var rows = resultSet.rows || [];
         rows.forEach(function(row) {
             var nodeId = row.node_id;
-            var node = nodesById[nodeId];
-            if (node) {
-                node.setUpdatedAt(row.updated_at || null);
-                node.setStatus(row.status);
+            var nodes = nodesById[nodeId];
+            if (nodes) {
+                nodes.forEach(function(node) {
+                    node.setUpdatedAt(row.updated_at || null);
+                    node.setStatus(row.status);
+                });
             }
         });
 

--- a/lib/service/database.js
+++ b/lib/service/database.js
@@ -148,7 +148,7 @@ DatabaseService.prototype.setUpdatedAtForSources = function(analysis, callback) 
 
     var self = this;
 
-    var sourceNodes = analysis.getSortedNodes().filter(function(node) { return node.type === Source.TYPE; });
+    var sourceNodes = analysis.getNodes().filter(function(node) { return node.type === Source.TYPE; });
     async.map(sourceNodes,
         function(node, done) {
             node.getAndSetUpdatedAt(self, done);

--- a/test/acceptance/regressions.js
+++ b/test/acceptance/regressions.js
@@ -1,0 +1,65 @@
+'use strict';
+
+var assert = require('assert');
+
+var Analysis = require('../../lib/analysis');
+
+var TestConfig = require('../test-config');
+
+describe('regressions', function() {
+
+    function duplicatedSourceStatusNotUpdated(nodeName) {
+        return {
+            id: nodeName,
+            type: 'source',
+            params: {
+                query: 'SELECT * FROM airbnb_rooms'
+            }
+        };
+    }
+
+    var sourcePending = {
+        id: 'a2',
+        type: 'point-in-polygon',
+        params: {
+            points_source: duplicatedSourceStatusNotUpdated('airbnb_rooms'),
+            polygons_source: {
+                id: 'a1',
+                type: 'trade-area',
+                params: {
+                    source: duplicatedSourceStatusNotUpdated('a0'),
+                    kind: 'car',
+                    time: 100,
+                    isolines: 1,
+                    dissolved: false
+                }
+            }
+        }
+    };
+
+    before(function(done) {
+        this.testConfig = TestConfig.create({ batch: { inlineExecution: true } });
+        Analysis.create(this.testConfig, sourcePending, done);
+    });
+
+    it('should get ready status after first creation', function (done) {
+        Analysis.create(this.testConfig, sourcePending, function (err, analysis) {
+            if (err) {
+                return done(err);
+            }
+
+            function checkNodeIsReady(node) {
+                var status = node.getStatus();
+                assert.equal(status, 'ready', 'Unexpected node status for ' + node.type);
+            }
+
+            var sortedNodes = analysis.getSortedNodes();
+            sortedNodes.forEach(checkNodeIsReady);
+
+            var nodesList = analysis.getNodes();
+            nodesList.forEach(checkNodeIsReady);
+
+            done();
+        });
+    });
+});

--- a/test/test-config.js
+++ b/test/test-config.js
@@ -1,16 +1,40 @@
+'use strict';
+
 var BATCH_API_ENDPOINT = 'http://127.0.0.1:8080/api/v1/sql/job';
 
-module.exports = {
-    db: {
-        host: 'localhost',
-        port: 5432,
-        dbname: 'analysis_api_test_db',
-        user: 'postgres',
-        pass: ''
-    },
-    batch: {
-        endpoint: BATCH_API_ENDPOINT,
-        username: 'localhost',
-        apiKey: 1234
-    }
-};
+function create (override) {
+    override = override || {
+        db: {},
+        batch: {}
+    };
+    override.db = override.db || {};
+    override.batch = override.batch || {};
+    return {
+        db: defaults(override.db, {
+            host: 'localhost',
+            port: 5432,
+            dbname: 'analysis_api_test_db',
+            user: 'postgres',
+            pass: ''
+        }),
+        batch: defaults(override.batch, {
+            endpoint: BATCH_API_ENDPOINT,
+            username: 'localhost',
+            apiKey: 1234
+        })
+    };
+}
+
+function defaults (obj, def) {
+    Object.keys(def).forEach(function(key) {
+        if (!obj.hasOwnProperty(key)) {
+            obj[key] = def[key];
+        }
+    });
+
+    return obj;
+}
+
+module.exports = create();
+
+module.exports.create = create;


### PR DESCRIPTION
Ready status was not being properly returned after first creation because input nodes were not being updated due the usage of getSortedNodes.
Method getSortedNodes returns a de-duplicated list of nodes, so internally referenced nodes not listed by that method were not being properly updated with the last known status and updatedAt time.