### PR TITLE
adding dot density as a camshaft analysis

### DIFF
--- a/examples/def/dot_density.js
+++ b/examples/def/dot_density.js
@@ -1,0 +1,21 @@
+var SOURCE_QUERY = 'select ST_BUFFER(CDB_LatLng(0,0)::geography, 2000)::geometry as the_geom ';
+var NO_POINTS = 10;
+
+var sourceAtmDef = {
+    type: 'source',
+    params: {
+        query: SOURCE_QUERY
+    }
+};
+
+
+var dotDensityDefinition = {
+    type: 'dot_density',
+    params: {
+        source: SOURCE_QUERY, 
+	points: 10
+    }
+};
+
+
+module.exports = dotDensityDefinition ;

--- a/examples/viewer/examples.js
+++ b/examples/viewer/examples.js
@@ -566,8 +566,8 @@ var examples = {
 
 	cartocss: ['#layer{',
 		'marker-width: 10;',
-		'  [category=\'dog\']{marker-fill:red;}',
-		'  [category=\'cat\']{marker-fill:blue;}',
+		'  [category=\'dog\']{marker-fill:#A16928;}',
+		'  [category=\'cat\']{marker-fill:#2887a1;}',
 		'}'].join('\n'),
 	center: [0, 0],
         zoom: 15

--- a/examples/viewer/examples.js
+++ b/examples/viewer/examples.js
@@ -525,6 +525,53 @@ var examples = {
         center: [40.01, -101.16],
         zoom: 4
     },
+
+    dot_density_explicit:{
+	name:'dot density explicit',
+        def:{
+	   'type': 'dot_density',
+           'params': {
+	      'source':{
+	         'type': 'source',
+                 'params':{
+		    'query': 'select ST_BUFFER(CDB_LatLng(0,0)::geography, 2000)::geometry as the_geom',
+		 }
+	       },
+              'points': 2000
+	    }
+	},
+	cartocss: ['#layer{',
+		   'marker-width: 10;',
+		   ' marker-fill:red;',
+		   '}'].join('\n'),
+	center: [0, 0],
+        zoom: 15
+    },
+    dot_density_with_categories:{
+	name:'dot density with categories',
+        def:{
+	  "id": "a0",
+	  "type": "dot_density",
+	  "params": {
+	    "source": {
+	      "type": "source",
+	      "params": {
+		"query": "select ST_BUFFER(CDB_LatLng(0,0)::geography, 2000)::geometry as the_geom, 100 as val, 'dog' as cat UNION ALL  select ST_BUFFER(CDB_LatLng(0,0)::geography, 2000)::geometry as the_geom, 50 as val, 'cat' as cat"
+	      }
+	    },
+	    "points_col_name": "val",
+	    "category_col_name": "cat"
+	  }
+	},
+
+	cartocss: ['#layer{',
+		'marker-width: 10;',
+		'  [category=\'dog\']{marker-fill:red;}',
+		'  [category=\'cat\']{marker-fill:blue;}',
+		'}'].join('\n'),
+	center: [0, 0],
+        zoom: 15
+    },
     phillyProperties: {
         name: 'philly properties',
         def: {

--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -10,7 +10,8 @@ var nodes = {
     PointInPolygon: require('./nodes/point-in-polygon'),
     PopulationInArea: require('./nodes/population-in-area'),
     Source: require('./nodes/source'),
-    TradeArea: require('./nodes/trade-area')
+    TradeArea: require('./nodes/trade-area'),
+    DotDensity: require('./nodes/dot-density')
 };
 
 module.exports = nodes;

--- a/lib/node/nodes/dot-density.js
+++ b/lib/node/nodes/dot-density.js
@@ -36,7 +36,7 @@ var queryTemplate = dot.template([
     'SELECT cdb_crankshaft.cdb_dot_density(_polygons.the_geom, {{=it.points_exp}}::INT) as the_geom',
     '{{? it.category_col_name}} , {{=it.category_col_name}}  as category{{?}}',
     'FROM _polygons'].join('\n')
-)
+);
 
 function query(it) {
     it.points_exp = it.points_col_name ? it.points_col_name : it.points;

--- a/lib/node/nodes/dot-density.js
+++ b/lib/node/nodes/dot-density.js
@@ -1,0 +1,44 @@
+'use strict';
+
+var dot = require('dot');
+dot.templateSettings.strip = false;
+
+var Node = require('../node');
+
+var TYPE = 'dot_density';
+var PARAMS = {
+    source: Node.PARAM.NODE(Node.GEOMETRY.POLYGON),
+    points_col_name: Node.PARAM.NULLABLE(Node.PARAM.STRING),
+    category_col_name: Node.PARAM.NULLABLE(Node.PARAM.STRING),
+    points: Node.PARAM.NULLABLE(Node.PARAM.NUMBER)
+};
+
+var DotDensity = Node.create(TYPE, PARAMS);
+
+module.exports = DotDensity; 
+module.exports.TYPE = TYPE;
+module.exports.PARAMS = PARAMS;
+
+DotDensity.prototype.sql = function() {
+    return query({
+        query: this.source.getQuery(),
+        points: this.points,
+	points_col_name: this.points_col_name,
+	category_col_name: this.category_col_name
+    });
+};
+
+var queryTemplate = dot.template([
+    'WITH',
+    '_polygons AS (',
+    ' {{=it.query}}',
+    ')',
+    'SELECT cdb_crankshaft.cdb_dot_density(_polygons.the_geom, {{=it.points_exp}}::INT) as the_geom',
+    '{{? it.category_col_name}} , {{=it.category_col_name}}  as category{{?}}',
+    'FROM _polygons'].join('\n')
+)
+
+function query(it) {
+    it.points_exp = it.points_col_name ? it.points_col_name : it.points;
+    return queryTemplate(it);
+ }


### PR DESCRIPTION
Adding Dot Density analysis definition (needs crankshaft to be installed) 

Can either take as params _points_ in which case it just generates that number of points within a polygon 

or _points_col_name_ which uses a column on the input query to populate the geometry and optionally _category_col_name_ which assigns those points a category in the returned table

@rochoa How does this look. Does the kind of variable overloading here that I am doing look good? Trying to get a feel of how we handle inputs to more complicated queries.

Also added two examples to the viewer 
