### PR TITLE
Improvements for moran queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 Released 2016-mm-dd
 
+ - Fix moran queries:
+   - Use `Rate` when denominator is provided.
+   - Make neighbours and permutations params optional.
  - Option to bump version an force analysis recalculation.
  - Optional params are casted to null when not provided.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.15.2
+## 0.16.0
 
 Released 2016-mm-dd
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 Released 2016-mm-dd
 
+ - Option to bump version an force analysis recalculation.
  - Optional params are casted to null when not provided.
 
 

--- a/examples/viewer/examples.js
+++ b/examples/viewer/examples.js
@@ -196,6 +196,60 @@ var dataObservatoryMeasureAdultsFirstLevelStudiesPercent = {
 };
 
 var examples = {
+    moran_sids2: {
+        name: 'cluster sids2',
+        def: {
+            id: 'moran-demo',
+            type: 'moran',
+            params: {
+                source: {
+                    type: 'source',
+                    params: {
+                        query: 'select * from sids2'
+                    }
+                },
+                numerator_column: 'bir79',
+                //denominator_column: 'sid79',
+                w_type: 'queen',
+                //neighbours: 5,
+                //permutations: 999,
+                significance: 0.05
+            }
+        },
+        cartocss: [
+            '@HL: #00695C;//dark teal',
+            '@HH: #4DB6AC;//light teal',
+            '@LL: #FB8C00;//light orange',
+            '@LH: #d84315;//dark orange',
+            '@notsig: transparent;',
+            '@null: transparent;',
+            '',
+            '#layer {',
+            '    polygon-opacity: 1;',
+            '    line-color: #FFF;',
+            '    line-width: 0;',
+            '    line-opacity: 1;',
+            '}',
+            '',
+            '#layer[quads="HH"] {',
+            '    polygon-fill: @HH;',
+            '}',
+            '#layer[quads="HL"] {',
+            '    polygon-fill: @HL;',
+            '}',
+            '#layer[quads="LH"] {',
+            '    polygon-fill: @LH;',
+            '}',
+            '#layer[quads="LL"] {',
+            '    polygon-fill: @LL;',
+            '}',
+            '#layer[significance >= 0.05] {',
+            '    polygon-fill: transparent;',
+            '}'
+        ].join('\n'),
+        center: [35.853, -79.563],
+        zoom: 7
+    },
     buffer_radius: {
         name: 'populated places radius',
         def: {

--- a/lib/node/node.js
+++ b/lib/node/node.js
@@ -31,6 +31,7 @@ var NODE_RESERVED_KEYWORDS = {
     updatedAt: 1,
     validateAndBuild: 1,
     json: 1,
+    version: 1,
     nodes: 1,
     inputNodes: 1,
     attrs: 1,
@@ -62,10 +63,19 @@ function Node() {
     this.attrs = {};
 
     this.json = {};
+
+    this.version = 0;
 }
 
 Node.prototype.id = function() {
-    return id(this.toJSON());
+    var json = this.toJSON();
+    if (this.version > 0) {
+        json = {
+            version: this.version,
+            json: json
+        };
+    }
+    return id(json);
 };
 
 Node.prototype.getQuery = function(applyFilters) {
@@ -311,6 +321,9 @@ module.exports.create = function createNode(type, expectedParams, options) {
         this.validateAndBuild();
         if (options.validate) {
             options.validate(this);
+        }
+        if (Number.isFinite(options.version) && options.version > 0) {
+            this.version = options.version;
         }
     }
     util.inherits(BaseNode, Node);

--- a/lib/node/nodes/moran.js
+++ b/lib/node/nodes/moran.js
@@ -2,33 +2,44 @@
 
 var Node = require('../node');
 
+var moranDenominatorQueryTemplate = Node.getSqlTemplateFn('moran-denominator');
 var moranQueryTemplate = Node.getSqlTemplateFn('moran');
 
 var TYPE = 'moran';
 var PARAMS = {
     source: Node.PARAM.NODE(Node.GEOMETRY.POLYGON),
     numerator_column: Node.PARAM.STRING,
-    denominator_column: Node.PARAM.STRING,
+    denominator_column: Node.PARAM.NULLABLE(Node.PARAM.STRING),
     significance: Node.PARAM.NUMBER,
-    neighbours: Node.PARAM.NUMBER,
-    permutations: Node.PARAM.NUMBER,
+    neighbours: Node.PARAM.NULLABLE(Node.PARAM.NUMBER),
+    permutations: Node.PARAM.NULLABLE(Node.PARAM.NUMBER),
     w_type: Node.PARAM.ENUM('knn', 'queen')
 };
 
-var Moran = Node.create(TYPE, PARAMS, { cache: true });
+var Moran = Node.create(TYPE, PARAMS, { cache: true, version: 1 });
 
 module.exports = Moran;
 module.exports.TYPE = TYPE;
 module.exports.PARAMS = PARAMS;
 
 Moran.prototype.sql = function() {
-    return moranQueryTemplate({
+    var neighbours = this.neighbours || 5;
+    var permutations = this.permutations || 999;
+    if (this.denominator_column === null) {
+        return moranQueryTemplate({
+            _query: this.source.getQuery(),
+            _numeratorColumn: this.numerator_column,
+            _wType: this.w_type,
+            _neighbours: neighbours,
+            _permutations: permutations
+        });
+    }
+    return moranDenominatorQueryTemplate({
         _query: this.source.getQuery(),
         _numeratorColumn: this.numerator_column,
         _denominatorColumn: this.denominator_column,
-        _significance: this.significance,
-        _neighbours: this.neighbours,
-        _permutations: this.permutations,
-        _wType: this.w_type
+        _wType: this.w_type,
+        _neighbours: neighbours,
+        _permutations: permutations
     });
 };

--- a/lib/node/nodes/sql/moran-denominator.sql
+++ b/lib/node/nodes/sql/moran-denominator.sql
@@ -4,9 +4,10 @@ input_query as (
 ),
 moran as (
   SELECT * FROM
-  cdb_crankshaft.CDB_AreasOfInterestLocal(
+  cdb_crankshaft.CDB_AreasOfInterestLocalRate(
     '{{=it._query}}',
     '{{=it._numeratorColumn}}',
+    '{{=it._denominatorColumn}}',
     '{{=it._wType}}',
     {{=it._neighbours}},
     {{=it._permutations}},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "camshaft",
-  "version": "0.15.2",
+  "version": "0.16.0",
   "description": "Analysis library to create data views from queries",
   "main": "./lib/analysis.js",
   "scripts": {


### PR DESCRIPTION
- Use `Rate` when denominator is provided.
- Make neighbours and permutations params optional.

For now `significance` param is ignored. A future PR will address the filtering based on that param.