### PR TITLE
Use a custom filter for significance param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 Released 2016-mm-dd
 
  - Fix moran queries:
+   - Use a custom filter for significance param, ignore significance for cache table.
    - Use `Rate` when denominator is provided.
    - Make neighbours and permutations params optional.
  - Add method to ignore param for the node id generation

--- a/lib/node/nodes/moran.js
+++ b/lib/node/nodes/moran.js
@@ -16,7 +16,18 @@ var PARAMS = {
     w_type: Node.PARAM.ENUM('knn', 'queen')
 };
 
-var Moran = Node.create(TYPE, PARAMS, { cache: true, version: 1 });
+var Moran = Node.create(TYPE, PARAMS, { cache: true, version: 1,
+    beforeCreate: function(node) {
+        node.ignoreParamForId('significance');
+        node.filters.__significance__ = {
+            type: 'range',
+            column: 'significance',
+            params: {
+                max: node.significance
+            }
+        };
+    }
+});
 
 module.exports = Moran;
 module.exports.TYPE = TYPE;


### PR DESCRIPTION
Ignores `significance` param for cache table so same cache table
can be reused for different significance params when the rest of the
params stay the same.