### PR TITLE
[work in progress] distance weighted knn prediction

### DIFF
--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -14,7 +14,8 @@ var nodes = {
     PopulationInArea: require('./nodes/population-in-area'),
     Source: require('./nodes/source'),
     TradeArea: require('./nodes/trade-area'),
-    WeightedCentroid: require('./nodes/weighted-centroid')
+    WeightedCentroid: require('./nodes/weighted-centroid'),
+    weightedKnn: require('./nodes/distance-weighted-knn')
 };
 
 module.exports = nodes;

--- a/lib/node/nodes/distance-weighted-knn.js
+++ b/lib/node/nodes/distance-weighted-knn.js
@@ -1,0 +1,37 @@
+'use strict';
+
+var Node = require('../node');
+var dot = require('dot');
+
+var TYPE = 'distance-weighted-knn';
+
+var PARAMS = {
+    source_geom: Node.PARAM.NODE(Node.GEOMETRY.POINT),
+    target_table: Node.PARAM.NODE(),
+    val_column: Node.PARAM.NODE(Node.NUMBER),
+    num_neighbors: Node.PARAM.NUMBER()
+};
+
+var weightedKnn = Node.create(TYPE, PARAMS, {cache: true});
+
+module.exports = weightedKnn;
+module.exports.TYPE = TYPE;
+module.exports.PARAMS = PARAMS;
+
+var weightedKnnQueryTemplate = dot.template([
+    'SELECT cdb_crankshaft.CDB_knnWeightedAverage(',
+    '  {{=it.source_geom}}, ',
+    '  array_agg(the_geom), ',
+    '  array_agg({{=it.val_column}}), ',
+    '  {{=it.num_neighbors}}) As knn_averaged ',
+    'FROM ({{=it.query}}) As q'
+  ].join('\n'));
+
+weightedKnn.prototype.sql = function() {
+    return kMeansQueryTemplate({
+        source_geom: this.source_geom,
+        val_column: this.val_column,
+        num_neighbors: this.num_neighbors,
+        query: this.source.getQuery()
+    });
+};

--- a/lib/node/nodes/distance-weighted-knn.js
+++ b/lib/node/nodes/distance-weighted-knn.js
@@ -28,7 +28,7 @@ var weightedKnnQueryTemplate = dot.template([
   ].join('\n'));
 
 weightedKnn.prototype.sql = function() {
-    return kMeansQueryTemplate({
+    return weightedKnnQueryTemplate({
         source_geom: this.source_geom,
         val_column: this.val_column,
         num_neighbors: this.num_neighbors,


### PR DESCRIPTION
As requested by @javisantana, I'm handing this PR over to @rochoa.  

The function needs to be swapped out with `CDB_SpatialInterpolation` which has a [different signature](https://github.com/CartoDB/crankshaft/blob/faa899cf8707adab4fc49834afa0a4d566abb481/src/pg/sql/08_interpolation.sql#L27-L35). This function is a more general version of the one I wrote. This PR depends on https://github.com/CartoDB/crankshaft/pull/71 for the deploy of the new function.

cc @AbelVM please let us know if there's something missing here.

Inputs need to be:
1. source geoms (array of geometries or table/analysis step where geometries come from)
2. source values (array of numeric values at each of the geoms in the first step)
3. point column (values for predicting a new measurement from)
4. method for comparison (one of: nearest neighbor, barycentric, or inverse-distance weighting) -- optional, default to nearest inverse-distance weighting (option 2),
5. if inverse-distance weighting, pick number of neighbors 
6. if inverse-distance weighting, pick decay strength (0 gives average of k nearest neighbors, 1 is weak decay, 2 is stronger decay, etc. etc.)

Output:
1. Interpolated value (numeric)
