### PR TITLE
Add Convex hull analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 Released 2016-mm-dd
  - Generate cartodb_id in weighted-centroid analysis #72.
+ - Add Convex hull analysis #76.
 
 
 ## 0.20.0

--- a/examples/viewer/examples.js
+++ b/examples/viewer/examples.js
@@ -885,6 +885,61 @@ var examples = {
         center: [40.44, -3.7],
         zoom: 12
     },
+    convex_hull: {
+        name: 'convex hull for kmeans',
+        def: {
+            id: 'convexHull',
+            type: 'convex-hull',
+            params: {
+                source: {
+                    id: 'kmeans',
+                    type: 'kmeans',
+                    params:{
+                        source: populatedPlacesSource,
+                        clusters : 10
+                    }
+                },
+                category_column: 'cluster_no'
+            }
+        },
+        cartocss:[
+            '#layer{',
+            '  polygon-fill: red;',
+            '  polygon-opacity: 0.4;',
+            '}'
+        ].join('\n'),
+        debugLayers: [
+            {
+                type: 'cartodb',
+                options: {
+                    source: { id: 'kmeans' },
+                    cartocss: [
+                        '@1: #E58606;',
+                        '@2: #5D69B1;',
+                        '@3: #52BCA3;',
+                        '@4: #99C945;',
+                        '@5: #2F8AC4;',
+                        '@6: #24796C;',
+                        '#layer{',
+                        '  [cluster_no =0]{marker-fill:@1;}',
+                        '  [cluster_no =1]{marker-fill:@2;}',
+                        '  [cluster_no =2]{marker-fill:@3;}',
+                        '  [cluster_no =3]{marker-fill:@4;}',
+                        '  [cluster_no =4]{marker-fill:@5;}',
+                        '  [cluster_no =5]{marker-fill:@6;}',
+                        '  marker-fill: grey;',
+                        '  marker-line-width: 0.5;',
+                        '  marker-allow-overlap: true;',
+                        '  marker-width: 10.0;',
+                        '}'
+                    ].join('\n'),
+                    cartocss_version: '2.3.0'
+                }
+            }
+        ],
+        center: [40.44, -3.7],
+        zoom: 3
+    },
     weighted_centroid_populated_builder: {
         name: 'weighted-centroid populated places',
         def: {

--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -3,6 +3,7 @@
 var nodes = {
     AggregateIntersection: require('./nodes/aggregate-intersection'),
     Buffer: require('./nodes/buffer'),
+    ConvexHull: require('./nodes/convex-hull'),
     DataObservatoryMeasure: require('./nodes/data-observatory-measure'),
     FilterByNodeColumn: require('./nodes/filter-by-node-column'),
     FilterCategory: require('./nodes/filter-category'),

--- a/lib/node/nodes/convex-hull.js
+++ b/lib/node/nodes/convex-hull.js
@@ -1,0 +1,33 @@
+'use strict';
+
+var Node = require('../node');
+var dot = require('dot');
+dot.templateSettings.strip = false;
+
+var TYPE = 'convex-hull';
+var PARAMS = {
+    source: Node.PARAM.NODE(Node.GEOMETRY.ANY),
+    category_column : Node.PARAM.NULLABLE(Node.PARAM.STRING())
+};
+
+var ConvexHull = Node.create(TYPE, PARAMS);
+
+module.exports = ConvexHull;
+module.exports.TYPE = TYPE;
+module.exports.PARAMS = PARAMS;
+
+var convexHullTpl = dot.template([
+    'SELECT',
+    '  row_number() over() as cartodb_id,',
+    '  {{? it._categoryColumn }}{{=it._categoryColumn}} as category,{{?}}',
+    '  ST_ConvexHull(ST_Collect(the_geom)) AS the_geom',
+    'FROM ({{=it._query}}) _analysis_source',
+    '{{? it._categoryColumn }}GROUP BY {{=it._categoryColumn}}{{?}}'
+].join('\n'));
+
+ConvexHull.prototype.sql = function() {
+    return convexHullTpl({
+        _query: this.source.getQuery(),
+        _categoryColumn: this.category_column
+    });
+};


### PR DESCRIPTION
Checklist:

- [x] Outputs a `the_geom geometry(Geometry, 4326)` column.
- [x] Outputs a `cartodb_id numeric` column.
- [ ] Uses `{cache: true}` option when it needs full knowledge of the table it. Hints: aggregations, window functions.
- [ ] Uses `{cache: true}` if it access external services.
- [x] Naming uses a-z lowercase and hyphens.
- [x] All mandatory params cannot be made optional.
- [x] Avoids using CTEs for join operations when result is not cached.

Closes #76.