### PR TITLE
Filter rank analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.20.1
 
 Released 2016-mm-dd
+ - Add Filter rank analysis #75.
  - Generate cartodb_id in weighted-centroid analysis #72.
  - Add Convex hull analysis #76.
 

--- a/examples/viewer/examples.js
+++ b/examples/viewer/examples.js
@@ -1334,6 +1334,30 @@ var examples = {
         center: [40.44, -3.7],
         zoom: 12
     },
+    filter_rank: {
+        name: 'populated places filter rank',
+        def: {
+            id: UUID,
+            type: 'filter-rank',
+            params: {
+                source: {
+                    id: 'a0',
+                    type: 'source',
+                    params: {
+                        query: 'select * from populated_places_simple'
+                    }
+                },
+                column: 'pop_max',
+                rank: 'top',
+                limit: 100
+            }
+        },
+        dataviews: {},
+        filters: {},
+        cartocss: CARTOCSS_POINTS,
+        center: [40.44, -3.7],
+        zoom: 3
+    },
     filterByNodeColumn: {
         name: 'filter by node column',
         def: {

--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -8,6 +8,7 @@ var nodes = {
     FilterByNodeColumn: require('./nodes/filter-by-node-column'),
     FilterCategory: require('./nodes/filter-category'),
     FilterRange: require('./nodes/filter-range'),
+    FilterRank: require('./nodes/filter-rank'),
     GeoreferenceAdminRegion: require('./nodes/georeference-admin-region'),
     GeoreferenceCity: require('./nodes/georeference-city'),
     GeoreferenceIpAddress: require('./nodes/georeference-ip-address'),

--- a/lib/node/nodes/filter-rank.js
+++ b/lib/node/nodes/filter-rank.js
@@ -1,0 +1,35 @@
+'use strict';
+
+var Node = require('../node');
+
+var TYPE = 'filter-rank';
+var PARAMS = {
+    source: Node.PARAM.NODE(Node.GEOMETRY.ANY),
+    column: Node.PARAM.STRING(),
+    rank: Node.PARAM.ENUM('top', 'bottom'),
+    limit: Node.PARAM.NUMBER(),
+    action: Node.PARAM.NULLABLE(Node.PARAM.ENUM('show', 'hide'), 'show')
+};
+
+var FilterRank = Node.create(TYPE, PARAMS, { cache: true });
+
+module.exports = FilterRank;
+module.exports.TYPE = TYPE;
+module.exports.PARAMS = PARAMS;
+
+var filterRankTemplate = Node.template([
+    'SELECT *',
+    'FROM ({{=it._query}}) _analysis_filter_rank',
+    'ORDER BY {{=it._column}} {{=it._orderDirection}}',
+    '{{=it._showHideAction}} {{=it._limitNumber}}'
+].join('\n'));
+
+FilterRank.prototype.sql = function() {
+    return filterRankTemplate({
+        _query: this.source.getQuery(),
+        _column: this.column,
+        _orderDirection: (this.rank === 'bottom' ? 'ASC' : 'DESC'),
+        _showHideAction: (this.action === 'hide' ? 'OFFSET' : 'LIMIT'),
+        _limitNumber: this.limit
+    });
+};


### PR DESCRIPTION
Checklist:

- [x] Outputs a `the_geom geometry(Geometry, 4326)` column.
- [x] Outputs a `cartodb_id numeric` column.
- [x] Uses `{cache: true}` option when it needs full knowledge of the table it. Hints: aggregations, window functions.
- [ ] Uses `{cache: true}` if it access external services.
- [x] Naming uses a-z lowercase and hyphens.
- [x] All mandatory params cannot be made optional.
- [x] Avoids using CTEs for join operations when result is not cached.

Closes #75