### PR TITLE
Adds centroid analysis

### DIFF
--- a/examples/viewer/examples.js
+++ b/examples/viewer/examples.js
@@ -25,6 +25,22 @@ var CARTOCSS_LINES = [
     '}'
 ].join('\n');
 
+var CARTOCSS_LABELS = [
+    '#layer::labels {',
+    '    text-name: [category];',
+    '    text-face-name: \'DejaVu Sans Book\';',
+    '    text-size: 10;',
+    '    text-label-position-tolerance: 10;',
+    '    text-fill: #000;',
+    '    text-halo-fill: #FFF;',
+    '    text-halo-radius: 1;',
+    '    text-dy: -10;',
+    '    text-allow-overlap: true;',
+    '    text-placement: point;',
+    '    text-placement-type: simple;',
+    '}',
+].join('\n');
+
 var sourceAtmDef = {
     type: 'source',
     params: {
@@ -304,6 +320,28 @@ var georeferenceStreetAddressDefinition = {
 
 
 var examples = {
+    centroid: {
+        name: 'populated places centroids adm0name',
+        def: {
+            id: UUID,
+            type: 'centroid',
+            params: {
+                source: {
+                    id: 'a0',
+                    type: 'source',
+                    params: {
+                        query: 'select * from populated_places_simple'
+                    }
+                },
+                category_column: 'adm0name'
+            }
+        },
+        dataviews: {},
+        filters: {},
+        cartocss: CARTOCSS_POINTS + CARTOCSS_LABELS,
+        center: [40.44, -3.7],
+        zoom: 3
+    },
     moran_sids2: {
         name: 'cluster sids2',
         def: {

--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -3,6 +3,7 @@
 var nodes = {
     AggregateIntersection: require('./nodes/aggregate-intersection'),
     Buffer: require('./nodes/buffer'),
+    Centroid: require('./nodes/centroid'),
     ConvexHull: require('./nodes/convex-hull'),
     DataObservatoryMeasure: require('./nodes/data-observatory-measure'),
     FilterByNodeColumn: require('./nodes/filter-by-node-column'),

--- a/lib/node/nodes/centroid.js
+++ b/lib/node/nodes/centroid.js
@@ -1,0 +1,41 @@
+'use strict';
+
+var Node = require('../node');
+
+var TYPE = 'centroid';
+
+var PARAMS = {
+    source : Node.PARAM.NODE(Node.GEOMETRY.ANY),
+    category_column : Node.PARAM.NULLABLE(Node.PARAM.STRING()),
+    aggregation: Node.PARAM.NULLABLE(Node.PARAM.STRING(), 'count'),
+    aggregation_column: Node.PARAM.NULLABLE(Node.PARAM.STRING())
+};
+
+var Centroid = Node.create(TYPE, PARAMS);
+
+module.exports = Centroid;
+module.exports.TYPE = TYPE;
+module.exports.PARAMS = PARAMS;
+
+var centroidTemplate = Node.template([
+    'SELECT',
+    '  row_number() over() as cartodb_id,',
+    '  ST_Centroid(ST_Collect(the_geom)) as the_geom,',
+    '  {{? it.categoryColumn }}{{=it.categoryColumn}} as category,{{?}}',
+    '  {{=it.aggregation}} as value',
+    'FROM ({{=it.query}}) q',
+    '{{? it.categoryColumn }}GROUP BY {{=it.categoryColumn}}{{?}}'
+].join('\n'));
+
+var aggregationFnQueryTpl = Node.template('{{=it._aggregationFn}}({{=it._aggregationColumn}})');
+
+Centroid.prototype.sql = function(){
+    return centroidTemplate({
+        query: this.source.getQuery(),
+        categoryColumn: this.category_column,
+        aggregation: aggregationFnQueryTpl({
+            _aggregationFn: this.aggregation,
+            _aggregationColumn: this.aggregation_column || 1
+        })
+    });
+};


### PR DESCRIPTION
Checklist:

- [x] Outputs a `the_geom geometry(Geometry, 4326)` column.
- [x] Outputs a `cartodb_id numeric` column.
- [ ] Uses `{cache: true}` option when it needs full knowledge of the table it. Hints: aggregations, window functions.
- [ ] Uses `{cache: true}` if it access external services.
- [x] Naming uses a-z lowercase and hyphens.
- [x] All mandatory params cannot be made optional.
- [x] Avoids using CTEs for join operations when result is not cached.

Closes #77.