### PR TITLE
Implemented analysis routing sequential

### DIFF
--- a/examples/viewer/examples.js
+++ b/examples/viewer/examples.js
@@ -318,6 +318,17 @@ var georeferenceStreetAddressDefinition = {
     }
 };
 
+var routingWaypointsDefinition = {
+    id: 'routing-waypoints-example',
+    type: 'routing-waypoints',
+    params: {
+        source: sourceAtmDef,
+        mode: 'car',
+        column_target: 'the_geom',
+        units: 'kilometers'
+    }
+};
+
 
 var examples = {
     centroid: {
@@ -1561,5 +1572,18 @@ var examples = {
        ].join('\n'),
        center: [40.44, -3.7],
        zoom: 6
-   }
+   },
+   'routing-waypointst': {
+       name: 'routing with waypoints',
+       def: routingWaypointsDefinition,
+       cartocss: [
+           '#layer{',
+           '  line-color: #F42220;',
+           '  line-width: 2;',
+           '  line-opacity: 0.7;',
+           '}'
+       ].join('\n'),
+       center: [40.44, -3.7],
+       zoom: 12
+    }
 };

--- a/examples/viewer/examples.js
+++ b/examples/viewer/examples.js
@@ -318,9 +318,9 @@ var georeferenceStreetAddressDefinition = {
     }
 };
 
-var routingWaypointsDefinition = {
-    id: 'routing-waypoints-example',
-    type: 'routing-waypoints',
+var routingSequentialDefinition = {
+    id: 'routing-sequential-example',
+    type: 'routing-sequential',
     params: {
         source: sourceAtmDef,
         mode: 'car',
@@ -328,7 +328,6 @@ var routingWaypointsDefinition = {
         units: 'kilometers'
     }
 };
-
 
 var examples = {
     centroid: {
@@ -1573,9 +1572,9 @@ var examples = {
        center: [40.44, -3.7],
        zoom: 6
    },
-   'routing-waypointst': {
-       name: 'routing with waypoints',
-       def: routingWaypointsDefinition,
+   'routing-sequentialt': {
+       name: 'routing with sequential',
+       def: routingSequentialDefinition,
        cartocss: [
            '#layer{',
            '  line-color: #F42220;',

--- a/lib/node/nodes/routing-sequential.js
+++ b/lib/node/nodes/routing-sequential.js
@@ -2,7 +2,7 @@
 
 var Node = require('../node');
 
-var TYPE = 'routing-waypoints';
+var TYPE = 'routing-sequential';
 var PARAMS = {
     source: Node.PARAM.NODE(Node.GEOMETRY.POINT),
     mode: Node.PARAM.ENUM('car', 'walk', 'bicycle', 'public_transport'),
@@ -12,14 +12,14 @@ var PARAMS = {
     order_type: Node.PARAM.NULLABLE(Node.PARAM.ENUM('asc', 'desc'), 'asc')
 };
 
-var RoutingWaypoints = Node.create(TYPE, PARAMS, { cache: true });
+var RoutingSequential = Node.create(TYPE, PARAMS, { cache: true });
 
-module.exports = RoutingWaypoints;
+module.exports = RoutingSequential;
 module.exports.TYPE = TYPE;
 module.exports.PARAMS = PARAMS;
 
-RoutingWaypoints.prototype.sql = function() {
-    return routingWaypointsQueryTemplate({
+RoutingSequential.prototype.sql = function() {
+    return routingSequentialQueryTemplate({
         source: this.source.getQuery(),
         columns: this.source.getColumns(true).join(', '),
         column_target: this.column_target,
@@ -31,7 +31,7 @@ RoutingWaypoints.prototype.sql = function() {
     });
 };
 
-var routingWaypointsQueryTemplate = Node.template([
+var routingSequentialQueryTemplate = Node.template([
     'SELECT',
     '  (route).duration,',
     '  (route).length,',
@@ -51,6 +51,6 @@ var routingWaypointsQueryTemplate = Node.template([
     '     {{=it.source}}',
     '    ) _cdb_analysis_ordered_source_point',
     '    {{?it.order_column}} ORDER BY {{=it.order_column}} {{=it.order_type}} {{?}}',
-    '  ) _cdb_analysis_routing_waypoints',
+    '  ) _cdb_analysis_routing_sequential',
     ') _cdb_analysis_routing'
 ].join('\n'));

--- a/lib/node/nodes/routing-waypoints.js
+++ b/lib/node/nodes/routing-waypoints.js
@@ -1,0 +1,44 @@
+'use strict';
+
+var Node = require('../node');
+
+var TYPE = 'routing-waypoints';
+var PARAMS = {
+    source: Node.PARAM.NODE(Node.GEOMETRY.POINT),
+    mode: Node.PARAM.ENUM('car', 'walk', 'bicycle', 'public_transport'),
+    column_target: Node.PARAM.STRING(),
+    units: Node.PARAM.NULLABLE(Node.PARAM.ENUM('kilometers', 'miles'), 'kilometers')
+};
+
+var RoutingWaypoints = Node.create(TYPE, PARAMS, { cache: true });
+
+module.exports = RoutingWaypoints;
+module.exports.TYPE = TYPE;
+module.exports.PARAMS = PARAMS;
+
+RoutingWaypoints.prototype.sql = function() {
+    return routingWaypointsQueryTemplate({
+        source: this.source.getQuery(),
+        column_target: this.column_target,
+        mode: this.mode,
+        mode_type: 'shortest',
+        units: this.units
+    });
+};
+
+var routingWaypointsQueryTemplate = Node.template([
+    'SELECT',
+    '  (route).duration,',
+    '  (route).length,',
+    '  (route).the_geom',
+    'FROM (',
+    '  SELECT',
+    '    cdb_route_with_waypoints(',
+    '      array_agg({{=it.column_target}}),',
+    '      \'{{=it.mode}}\',',
+    '      ARRAY[\'mode_type={{=it.mode_type}}\']::text[],',
+    '      \'{{=it.units}}\'',
+    '    ) as route',
+    '  FROM ( {{=it.source}} ) _cdb_analysis_routing_waypoints',
+    ') _cdb_analysis_routing'
+].join('\n'));

--- a/lib/node/nodes/routing-waypoints.js
+++ b/lib/node/nodes/routing-waypoints.js
@@ -7,7 +7,9 @@ var PARAMS = {
     source: Node.PARAM.NODE(Node.GEOMETRY.POINT),
     mode: Node.PARAM.ENUM('car', 'walk', 'bicycle', 'public_transport'),
     column_target: Node.PARAM.STRING(),
-    units: Node.PARAM.NULLABLE(Node.PARAM.ENUM('kilometers', 'miles'), 'kilometers')
+    units: Node.PARAM.NULLABLE(Node.PARAM.ENUM('kilometers', 'miles'), 'kilometers'),
+    order_column:  Node.PARAM.NULLABLE(Node.PARAM.STRING(), 'cartodb_id'),
+    order_type: Node.PARAM.NULLABLE(Node.PARAM.ENUM('asc', 'desc'), 'asc')
 };
 
 var RoutingWaypoints = Node.create(TYPE, PARAMS, { cache: true });
@@ -19,10 +21,13 @@ module.exports.PARAMS = PARAMS;
 RoutingWaypoints.prototype.sql = function() {
     return routingWaypointsQueryTemplate({
         source: this.source.getQuery(),
+        columns: this.source.getColumns(true).join(', '),
         column_target: this.column_target,
         mode: this.mode,
         mode_type: 'shortest',
-        units: this.units
+        units: this.units,
+        order_column:  this.order_column,
+        order_type: this.order_type
     });
 };
 
@@ -39,6 +44,13 @@ var routingWaypointsQueryTemplate = Node.template([
     '      ARRAY[\'mode_type={{=it.mode_type}}\']::text[],',
     '      \'{{=it.units}}\'',
     '    ) as route',
-    '  FROM ( {{=it.source}} ) _cdb_analysis_routing_waypoints',
+    '  FROM (',
+    '    SELECT',
+    '      *',
+    '    FROM (',
+    '     {{=it.source}}',
+    '    ) _cdb_analysis_ordered_source_point',
+    '    {{?it.order_column}} ORDER BY {{=it.order_column}} {{=it.order_type}} {{?}}',
+    '  ) _cdb_analysis_routing_waypoints',
     ') _cdb_analysis_routing'
 ].join('\n'));

--- a/test/fixtures/cdb_route_with_waypoints.sql
+++ b/test/fixtures/cdb_route_with_waypoints.sql
@@ -1,0 +1,14 @@
+CREATE OR REPLACE FUNCTION cdb_route_with_waypoints(
+  waypoints geometry(Point, 4326)[],
+  mode TEXT,
+  options text[] DEFAULT ARRAY[]::text[],
+  units text DEFAULT 'kilometers',
+  OUT duration integer,
+  OUT length real,
+  OUT the_geom geometry)
+AS $$
+  SELECT
+    trunc(random() * 1000)::integer duration,
+    ST_Distance(waypoints[1], waypoints[array_length(waypoints, 1)])::real length,
+    ST_MakeLine(waypoints) the_geom
+$$ LANGUAGE 'sql' IMMUTABLE STRICT;


### PR DESCRIPTION
For new analysis use the following checklist:

- [x] Outputs a `the_geom geometry(Geometry, 4326)` column.
- [ ] Outputs a `cartodb_id numeric` column.
- [x] Uses `{cache: true}` option when it needs full knowledge of the table it. Hints: aggregations, window functions.
- [x] Uses `{cache: true}` if it access external services.
- [x] Naming uses a-z lowercase and hyphens.
- [x] All mandatory params cannot be made optional.
- [x] Avoids using CTEs for join operations when result is not cached.

cc @rochoa 