### PR TITLE
Implemented analysis routing to layer all to all

### DIFF
--- a/examples/viewer/examples.js
+++ b/examples/viewer/examples.js
@@ -1511,6 +1511,31 @@ var examples = {
         center: [40.44, -3.7],
         zoom: 3
     },
+    filter_grouped_rank: {
+        name: 'city most populated by country (filter grouped rank)',
+        def: {
+            id: UUID,
+            type: 'filter-grouped-rank',
+            params: {
+                source: {
+                    id: 'a0',
+                    type: 'source',
+                    params: {
+                        query: 'select * from populated_places_simple'
+                    }
+                },
+                column: 'pop_max',
+                rank: 'top',
+                group: 'iso_a2',
+                max: 1
+            }
+        },
+        dataviews: {},
+        filters: {},
+        cartocss: CARTOCSS_POINTS,
+        center: [40.44, -3.7],
+        zoom: 3
+    },
     filterByNodeColumn: {
         name: 'filter by node column',
         def: {

--- a/examples/viewer/examples.js
+++ b/examples/viewer/examples.js
@@ -338,7 +338,8 @@ var routingToLayerAllToAllDefinition = {
         target: sourceAtmDef,
         target_column: 'bank',
         mode: 'car',
-        units: 'kilometers'
+        units: 'kilometers',
+        closest: true
     }
 };
 

--- a/examples/viewer/examples.js
+++ b/examples/viewer/examples.js
@@ -318,6 +318,18 @@ var georeferenceStreetAddressDefinition = {
     }
 };
 
+var routingToLayerAllToAllDefinition = {
+    id: 'routing-to-layer-all-to-all-example',
+    type: 'routing-to-layer-all-to-all',
+    params: {
+        source: sourceAtmDef,
+        source_column: 'bank',
+        target: sourceAtmDef,
+        target_column: 'bank',
+        mode: 'car',
+        units: 'kilometers'
+    }
+};
 
 var examples = {
     centroid: {
@@ -1561,5 +1573,18 @@ var examples = {
        ].join('\n'),
        center: [40.44, -3.7],
        zoom: 6
-   }
+   },
+   'routing-to-layer-all-to-all': {
+        name: 'routing to layer all to all',
+        def: routingToLayerAllToAllDefinition,
+        cartocss: [
+            '#layer{',
+            '  line-color: #F42220;',
+            '  line-width: 2;',
+            '  line-opacity: 0.7;',
+            '}'
+        ].join('\n'),
+        center: [40.44, -3.7],
+        zoom: 12
+    }
 };

--- a/lib/filter/grouped-rank.js
+++ b/lib/filter/grouped-rank.js
@@ -1,0 +1,38 @@
+'use strict';
+
+var dot = require('dot');
+dot.templateSettings.strip = false;
+
+var Range = require('./range');
+
+var groupRankQueryTemplate = dot.template([
+    'SELECT *,',
+    '  rank() OVER (',
+    '    PARTITION BY {{=it._groupColumn}}',
+    '    ORDER BY {{=it._orderColumn}} {{=it._orderDirection}}',
+    '  ) AS rank',
+    'FROM ({{=it._query}}) _cdb_filter_grouped_rank',
+].join('\n'));
+
+function GroupedRank(column, filterParams) {
+    this.column = column.name;
+    this.rank = filterParams.rank;
+    this.group = filterParams.group;
+    this.rangeFilter = new Range({ name: 'rank' }, {
+        min: filterParams.minRank,
+        max: filterParams.maxRank
+    });
+}
+
+module.exports = GroupedRank;
+
+GroupedRank.prototype.sql = function(rawSql) {
+    var groupRankQuery = groupRankQueryTemplate({
+        _query: rawSql,
+        _orderColumn: this.column,
+        _groupColumn: this.group,
+        _orderDirection: (this.rank === 'bottom' ? 'ASC' : 'DESC'),
+    });
+
+    return this.rangeFilter.sql(groupRankQuery);
+};

--- a/lib/filter/grouped-rank.js
+++ b/lib/filter/grouped-rank.js
@@ -19,8 +19,8 @@ function GroupedRank(column, filterParams) {
     this.rank = filterParams.rank;
     this.group = filterParams.group;
     this.rangeFilter = new Range({ name: 'rank' }, {
-        min: filterParams.minRank,
-        max: filterParams.maxRank
+        min: filterParams.min,
+        max: filterParams.max
     });
 }
 

--- a/lib/filter/query-builder.js
+++ b/lib/filter/query-builder.js
@@ -20,7 +20,9 @@ module.exports.getSql = function QueryBuilder$getSql(query, filters, applyFilter
 
 var filters = {
     category: require('./category'),
-    range: require('./range')
+    range: require('./range'),
+    rank: require('./rank'),
+    'grouped-rank': require('./grouped-rank')
 };
 
 function createFilter(columns, filterDefinition) {

--- a/lib/node/nodes/filter-grouped-rank.js
+++ b/lib/node/nodes/filter-grouped-rank.js
@@ -1,0 +1,33 @@
+'use strict';
+
+var Node = require('../node');
+var GroupedRank = require('../../filter/grouped-rank');
+
+var TYPE = 'filter-grouped-rank';
+var PARAMS = {
+    source: Node.PARAM.NODE(Node.GEOMETRY.ANY),
+    column: Node.PARAM.STRING(),
+    rank: Node.PARAM.ENUM('top', 'bottom'),
+    group: Node.PARAM.STRING(),
+    min: Node.PARAM.NULLABLE(Node.PARAM.NUMBER()),
+    max: Node.PARAM.NULLABLE(Node.PARAM.NUMBER())
+};
+
+var FilterGroupedRank = Node.create(TYPE, PARAMS, {
+    beforeCreate: function (node) {
+        node.groupedRank = new GroupedRank({ name: node.column }, {
+            rank: node.rank,
+            group: node.group,
+            min: node.min,
+            max: node.max
+        });
+    }
+});
+
+module.exports = FilterGroupedRank;
+module.exports.TYPE = TYPE;
+module.exports.PARAMS = PARAMS;
+
+FilterGroupedRank.prototype.sql = function() {
+    return this.groupedRank.sql(this.source.getQuery());
+};

--- a/lib/node/nodes/routing-to-layer-all-to-all.js
+++ b/lib/node/nodes/routing-to-layer-all-to-all.js
@@ -1,0 +1,70 @@
+'use strict';
+
+var Node = require('../node');
+
+var OURTER_ALIAS = '_cdb_analysis_routing';
+var SOURCE_ALIAS = '_cdb_analysis_source';
+var TARGET_ALIAS = '_cdb_analysis_target';
+
+var TYPE = 'routing-to-layer-all-to-all';
+var PARAMS = {
+    source: Node.PARAM.NODE(Node.GEOMETRY.POINT),
+    source_column: Node.PARAM.STRING(),
+    target: Node.PARAM.NODE(Node.GEOMETRY.POINT),
+    target_column: Node.PARAM.STRING(),
+    mode: Node.PARAM.ENUM('car', 'walk', 'bicycle', 'public_transport'),
+    units: Node.PARAM.NULLABLE(Node.PARAM.ENUM('kilometers', 'miles'), 'kilometers'),
+};
+
+var RoutingToLayerAllToAll = Node.create(TYPE, PARAMS, { cache: true });
+
+module.exports = RoutingToLayerAllToAll;
+module.exports.TYPE = TYPE;
+module.exports.PARAMS = PARAMS;
+
+RoutingToLayerAllToAll.prototype.sql = function() {
+    return routingToLayerQueryTemplate({
+        source: this.source.getQuery(),
+        source_alias: SOURCE_ALIAS,
+        source_column: this.source_column,
+        source_columns: this.source.getColumns(true).map(function (column) {
+            return SOURCE_ALIAS + '.' + column;
+        }).join(', '),
+        final_columns: this.source.getColumns(true).map(function (column) {
+            return OURTER_ALIAS + '.' + column;
+        }).join(', '),
+        final_alias: OURTER_ALIAS,
+        target: this.target.getQuery(),
+        target_column: this.target_column,
+        target_alias: TARGET_ALIAS,
+        mode: this.mode,
+        mode_type: 'shortest',
+        units: this.units
+    });
+};
+
+var routingToLayerQueryTemplate = Node.template([
+    'SELECT',
+    '  (route).duration,',
+    '  (route).length,',
+    '  (route).the_geom,',
+    '  {{=it.final_columns}}',
+    'FROM (',
+    '  SELECT',
+    '    cdb_route_point_to_point(',
+    '      _cdb_analysis_source.the_geom,',
+    '      _cdb_analysis_target.the_geom,',
+    '      \'{{=it.mode}}\',',
+    '      ARRAY[\'mode_type={{=it.mode_type}}\']::text[],',
+    '      \'{{=it.units}}\'',
+    '    ) as route,',
+    '    {{=it.source_columns}}',
+    '  FROM (',
+    '    {{=it.source}}',
+    '  ) {{=it.source_alias}}, (',
+    '    {{=it.target}}',
+    '  ) {{=it.target_alias}}',
+    '  WHERE',
+    '    {{=it.source_alias}}.{{=it.source_column}} = {{=it.target_alias}}.{{=it.target_column}}',
+    ') {{=it.final_alias}}'
+].join('\n'));

--- a/lib/node/nodes/routing-to-layer-all-to-all.js
+++ b/lib/node/nodes/routing-to-layer-all-to-all.js
@@ -14,16 +14,32 @@ var PARAMS = {
     target_column: Node.PARAM.STRING(),
     mode: Node.PARAM.ENUM('car', 'walk', 'bicycle', 'public_transport'),
     units: Node.PARAM.NULLABLE(Node.PARAM.ENUM('kilometers', 'miles'), 'kilometers'),
+    closest: Node.PARAM.BOOLEAN()
 };
 
-var RoutingToLayerAllToAll = Node.create(TYPE, PARAMS, { cache: true });
+var RoutingToLayerAllToAll = Node.create(TYPE, PARAMS, { cache: true,
+    beforeCreate: function (node) {
+        if (node.closest) {
+            node.ignoreParamForId('duration');
+            node.filters.__duration__ = {
+                type: 'grouped-rank',
+                column: 'duration',
+                params: {
+                    group: node.source_column,
+                    rank: 'bottom',
+                    maxRank: 1
+                }
+            };
+        }
+    }
+});
 
 module.exports = RoutingToLayerAllToAll;
 module.exports.TYPE = TYPE;
 module.exports.PARAMS = PARAMS;
 
 RoutingToLayerAllToAll.prototype.sql = function() {
-    return routingToLayerQueryTemplate({
+    var routingToLayerQuery = routingToLayerQueryTemplate({
         source: this.source.getQuery(),
         source_alias: SOURCE_ALIAS,
         source_column: this.source_column,
@@ -41,6 +57,8 @@ RoutingToLayerAllToAll.prototype.sql = function() {
         mode_type: 'shortest',
         units: this.units
     });
+
+    return routingToLayerQuery;
 };
 
 var routingToLayerQueryTemplate = Node.template([

--- a/lib/node/nodes/routing-to-layer-all-to-all.js
+++ b/lib/node/nodes/routing-to-layer-all-to-all.js
@@ -27,7 +27,7 @@ var RoutingToLayerAllToAll = Node.create(TYPE, PARAMS, { cache: true,
                 params: {
                     group: node.source_column,
                     rank: 'bottom',
-                    maxRank: 1
+                    max: 1
                 }
             };
         }


### PR DESCRIPTION
For new analysis use the following checklist:

- [x] Outputs a `the_geom geometry(Geometry, 4326)` column.
- [x] Outputs a `cartodb_id numeric` column.
- [ ] Uses `{cache: true}` option when it needs full knowledge of the table it. Hints: aggregations, window functions.
- [x] Uses `{cache: true}` if it access external services.
- [x] Naming uses a-z lowercase and hyphens.
- [x] All mandatory params cannot be made optional.
- [x] Avoids using CTEs for join operations when result is not cached.

cc @rochoa 