### PR TITLE
Intersection nodes gets augmented with columns from target node

### DIFF
--- a/examples/viewer/examples.js
+++ b/examples/viewer/examples.js
@@ -25,6 +25,17 @@ var CARTOCSS_LINES = [
     '}'
 ].join('\n');
 
+var CARTOCSS_POLYGONS = [
+    '#layer {',
+    '  polygon-fill: red;',
+    '  polygon-opacity: 0.6;',
+    '  polygon-opacity: 0.7;',
+    '  line-color: #FFF;',
+    '  line-width: 0.5;',
+    '  line-opacity: 1;',
+    '}'
+].join('\n');
+
 var CARTOCSS_LABELS = [
     '#layer::labels {',
     '    text-name: [category];',
@@ -1224,6 +1235,68 @@ var examples = {
             '}'
         ].join('\n'),
         center: [40.009, -75.134],
+        zoom: 12
+    },
+    builder_intersection: {
+        name: '[builder] airbnb and districts intersection',
+        def: {
+            id: 'intersection-example-1',
+            type: 'intersection',
+            params: {
+                source: {
+                    id: 'airbnb-source',
+                    type: 'source',
+                    params: {
+                        query: 'select * from airbnb_madrid_oct_2015_listings'
+                    }
+                },
+                target: {
+                    id: 'barrios-source',
+                    type: 'source',
+                    params: {
+                        query: 'select * from barrios'
+                    }
+                }
+            }
+        },
+        cartocss: CARTOCSS_POINTS + '\n' + [
+            '#categories {',
+            '  marker-fill: ramp([target_nombre], colorbrewer(Paired, 7), category);',
+            '}'
+        ].join('\n'),
+        center: [40.44, -3.7],
+        zoom: 12
+    },
+    builder_aggregate_intersection: {
+        name: '[builder] airbnb and districts intersection with avg price aggregation',
+        def: {
+            id: 'aggregate-intersection-example-1',
+            type: 'aggregate-intersection',
+            params: {
+                source: {
+                    id: 'airbnb-source',
+                    type: 'source',
+                    params: {
+                        query: 'select * from airbnb_madrid_oct_2015_listings'
+                    }
+                },
+                target: {
+                    id: 'barrios-source',
+                    type: 'source',
+                    params: {
+                        query: 'select * from barrios'
+                    }
+                },
+                aggregate_function: 'avg',
+                aggregate_column: 'price'
+            }
+        },
+        cartocss: CARTOCSS_POLYGONS + '\n' + [
+            '#polygon {',
+            '  polygon-fill: ramp([avg_price], colorbrewer(Reds));',
+            '}'
+        ].join('\n'),
+        center: [40.44, -3.7],
         zoom: 12
     },
     weighted_centroid_properties: {

--- a/lib/node/nodes/intersection.js
+++ b/lib/node/nodes/intersection.js
@@ -8,7 +8,7 @@ var PARAMS = {
     target: Node.PARAM.NODE(Node.GEOMETRY.ANY)
 };
 
-var Intersection = Node.create(TYPE, PARAMS);
+var Intersection = Node.create(TYPE, PARAMS, { version: 1 });
 
 module.exports = Intersection;
 module.exports.TYPE = TYPE;
@@ -18,12 +18,15 @@ module.exports.PARAMS = PARAMS;
 Intersection.prototype.sql = function() {
     return queryTemplate({
         sourceQuery: this.source.getQuery(),
-        targetQuery: this.target.getQuery()
+        targetQuery: this.target.getQuery(),
+        columns: ['_cdb_analysis_source.*'].concat(this.target.getColumns(true).map(function (name) {
+            return '_cdb_analysis_target.' + name + ' as target_' + name;
+        })).join(',')
     });
 };
 
 var queryTemplate = Node.template([
-    'SELECT _cdb_analysis_source.*',
+    'SELECT {{=it.columns}}',
     'FROM ({{=it.sourceQuery}}) _cdb_analysis_source, ({{=it.targetQuery}}) _cdb_analysis_target',
     'WHERE ST_Intersects(_cdb_analysis_target.the_geom, _cdb_analysis_source.the_geom)'
 ].join('\n'));


### PR DESCRIPTION
Checklist:

- [x] Outputs a `the_geom geometry(Geometry, 4326)` column.
- [x] Outputs a `cartodb_id numeric` column.
- [ ] Uses `{cache: true}` option when it needs full knowledge of the table it. Hints: aggregations, window functions.
- [ ] Uses `{cache: true}` if it access external services.
- [x] Naming uses a-z lowercase and hyphens.
- [x] All mandatory params cannot be made optional.
- [x] Avoids using CTEs for join operations when result is not cached.

