### PR TITLE
WIP - Stubbing out segmentation node

### DIFF
--- a/lib/node/nodes/segmentation.js
+++ b/lib/node/nodes/segmentation.js
@@ -1,0 +1,19 @@
+'use strict';
+
+var Node = require('../node');
+
+var TYPE = 'market-prediction';
+var PARAMS = {
+    source: Node.PARAM.NODE(Node.GEOMETRY.POLYGON),
+    target: Node.PARAM.NODE(Node.GEOMETRY.POLYGON)
+   };
+
+var MarketPrediction = Node.create(TYPE, PARAMS, { cache: true });
+
+module.exports = MarketPrediction;
+module.exports.TYPE = TYPE;
+module.exports.PARAMS = PARAMS;
+
+MarketPrediction.sql = function(){
+    return '';
+}


### PR DESCRIPTION
This is a placeholder for the segmentation analysis that works with this crankshaft pull request: 
https://github.com/CartoDB/crankshaft/pull/70

The function you want to wrap up is this one : 

https://github.com/CartoDB/crankshaft/blob/5f98735ce97bb040d1233252e2fce40a175de728/doc/12_segmentation.md#cdb_createandpredictsegmenttarget-numeric-train_features-numeric-prediction_features-numeric-prediction_ids-numeric

To use it you need to use the pyagg helper function to get the data in to the segmentation. See the example here: 

https://github.com/CartoDB/crankshaft/blob/5f98735ce97bb040d1233252e2fce40a175de728/doc/12_segmentation.md#example-usage-1

Open questions are how much of the GradientBoosting hyper-parameters do we expose in the editor. 

For new analysis use the following checklist:
- [ ] Outputs a `the_geom geometry(Geometry, 4326)` column.
- [ ] Outputs a `cartodb_id numeric` column.
- [ ] Uses `{cache: true}` option when it needs full knowledge of the table it. Hints: aggregations, window functions.
- [ ] Uses `{cache: true}` if it access external services.
- [ ] Naming uses a-z lowercase and hyphens.
- [ ] All mandatory params cannot be made optional.
- [ ] Avoids using CTEs for join operations when result is not cached.
