### PR TITLE
Allow any geometry in weighted-centroid

### DIFF
--- a/examples/viewer/examples.js
+++ b/examples/viewer/examples.js
@@ -1047,6 +1047,35 @@ var examples = {
         center: [40.44, -3.7],
         zoom: 3
     },
+    weighted_centroid_polygons_builder: {
+        name: 'weighted-centroid populated places buffer',
+        def: {
+            id: 'weightedCentroid',
+            type: 'weighted-centroid',
+            params:{
+                source: {
+                    id: 'BUFFER',
+                    type: 'buffer',
+                    params:{
+                        source: {
+                            id: 'kmeans',
+                            type: 'kmeans',
+                            params:{
+                                source: populatedPlacesSource,
+                                clusters: 10
+                            }
+                        },
+                        radius: 100000
+                    }
+                },
+                weight_column: 'pop_max',
+                category_column: 'cluster_no'
+            }
+        },
+        cartocss: CARTOCSS_POINTS,
+        center: [40.44, -3.7],
+        zoom: 3
+    },
     weighted_centroid_aggregation_function: {
         name: 'weighted-centroid populated places aggregation',
         def: {

--- a/lib/node/nodes/weighted-centroid.js
+++ b/lib/node/nodes/weighted-centroid.js
@@ -5,14 +5,14 @@ var Node = require('../node');
 var TYPE = 'weighted-centroid';
 
 var PARAMS = {
-    source : Node.PARAM.NODE(Node.GEOMETRY.POINT),
+    source : Node.PARAM.NODE(Node.GEOMETRY.ANY),
     weight_column : Node.PARAM.STRING(),
     category_column : Node.PARAM.NULLABLE(Node.PARAM.STRING()),
     aggregation: Node.PARAM.NULLABLE(Node.PARAM.STRING(), 'count'),
     aggregation_column: Node.PARAM.NULLABLE(Node.PARAM.STRING())
 };
 
-var WeightedCentroid = Node.create(TYPE, PARAMS, {cache: true, version: 2});
+var WeightedCentroid = Node.create(TYPE, PARAMS, {cache: true, version: 3});
 
 module.exports = WeightedCentroid;
 module.exports.TYPE = TYPE;
@@ -21,7 +21,7 @@ module.exports.PARAMS = PARAMS;
 var weightedCentroidTemplate = Node.template([
     'SELECT',
     '  row_number() over() as cartodb_id,',
-    '  cdb_crankshaft.CDB_WeightedMean(the_geom, {{=it.weightColumn}}::NUMERIC) as the_geom,',
+    '  cdb_crankshaft.CDB_WeightedMean(ST_Centroid(the_geom), {{=it.weightColumn}}::NUMERIC) as the_geom,',
     '  {{? it.categoryColumn }}{{=it.categoryColumn}} as category,{{?}}',
     '  {{=it.aggregation}} as value',
     'FROM ({{=it.query}}) q',


### PR DESCRIPTION
Checklist:

- [ ] Outputs a `the_geom geometry(Geometry, 4326)` column.
- [ ] Outputs a `cartodb_id numeric` column.
- [ ] Uses `{cache: true}` option when it needs full knowledge of the table it. Hints: aggregations, window functions.
- [ ] Uses `{cache: true}` if it access external services.
- [ ] Naming uses a-z lowercase and hyphens.
- [ ] All mandatory params cannot be made optional.
- [ ] Avoids using CTEs for join operations when result is not cached.

---

As cdb_crankshaft.CDB_WeightedMean does not support polygons/linestrings we use ST_Centroid.
This workaround will be reverted once https://github.com/CartoDB/crankshaft/issues/79 is closed.

Closes #100.