### PR TITLE
Aggregate intersection optional aggregate column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 Released 2016-mm-dd
 
+ - Make the aggregation_column param of the aggreagation-intersection optional when the operation is `count` #102.
  - Improves cached nodes and filters inner working: cache table target name independent from filters #114.
  - Adds markov analysis #112.
  - Skips retrieval of last update time for root source nodes #110

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 0.25.1
+## 0.26.0
 
 Released 2016-mm-dd
+
+ - Improves cached nodes and filters inner working: cache table target name independent from filters #114.
+ - Adds markov analysis #112.
+ - Skips retrieval of last update time for root source nodes #110
 
 
 ## 0.25.0

--- a/lib/node/nodes/aggregate-intersection.js
+++ b/lib/node/nodes/aggregate-intersection.js
@@ -7,7 +7,7 @@ var PARAMS = {
     source: Node.PARAM.NODE(Node.GEOMETRY.ANY),
     target: Node.PARAM.NODE(Node.GEOMETRY.ANY),
     aggregate_function: Node.PARAM.ENUM('avg', 'count', 'max', 'min', 'sum'),
-    aggregate_column: Node.PARAM.STRING()
+    aggregate_column: Node.PARAM.NULLABLE(Node.PARAM.STRING())
 };
 
 var AggregateIntersection = Node.create(TYPE, PARAMS, { version: 1 });
@@ -17,20 +17,23 @@ module.exports.TYPE = TYPE;
 module.exports.PARAMS = PARAMS;
 
 AggregateIntersection.prototype.sql = function() {
-    return query({
+    var finalColumnName = this.aggregate_function;
+    var qualifiedAggregateColumn = '_cdb_analysis_target.';
+    if (this.aggregate_column === null) {
+        qualifiedAggregateColumn += '*';
+    } else {
+        qualifiedAggregateColumn += this.aggregate_column;
+        finalColumnName += '_' + this.aggregate_column;
+    }
+    return queryAggregateTemplate({
         sourceQuery: this.source.getQuery(), // polygons
         targetQuery: this.target.getQuery(), // points
-        columnNames: this.source.getColumns(),
-        aggregate_function: this.aggregate_function,
-        aggregate_column: this.aggregate_column
+        sourceColumns: setAliasPrefixToColumnNames(this.source.getColumns(), '_cdb_analysis_source'),
+        aggregateFunction: this.aggregate_function,
+        qualifiedAggregateColumn: qualifiedAggregateColumn,
+        aggregateFinalColumnName: finalColumnName
     });
 };
-
-function query(it) {
-    it.sourceColumns = setAliasPrefixToColumnNames(it.columnNames, '_cdb_analysis_source');
-    it.prefixed_aggregate_column = '_cdb_analysis_target.' + it.aggregate_column;
-    return queryAggregateTemplate(it);
-}
 
 function setAliasPrefixToColumnNames(columnNames, alias) {
     return columnNames.map(function (name) {
@@ -41,8 +44,7 @@ function setAliasPrefixToColumnNames(columnNames, alias) {
 var queryAggregateTemplate = Node.template([
     'SELECT',
     '  {{=it.sourceColumns}},',
-    '  {{=it.aggregate_function}}({{=it.prefixed_aggregate_column}})',
-    '   as {{=it.aggregate_function}}_{{=it.aggregate_column}}',
+    '  {{=it.aggregateFunction}}({{=it.qualifiedAggregateColumn}}) as {{=it.aggregateFinalColumnName}}',
     'FROM ({{=it.sourceQuery}}) _cdb_analysis_source, ({{=it.targetQuery}}) _cdb_analysis_target',
     'WHERE ST_Intersects(_cdb_analysis_source.the_geom, _cdb_analysis_target.the_geom)',
     'GROUP BY',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "camshaft",
-  "version": "0.25.1",
+  "version": "0.26.0",
   "description": "Analysis library to create data views from queries",
   "main": "./lib/analysis.js",
   "scripts": {


### PR DESCRIPTION
Closes #102.

Checklist:

- [x] Outputs a `the_geom geometry(Geometry, 4326)` column.
- [x] Outputs a `cartodb_id numeric` column.
- [ ] Uses `{cache: true}` option when it needs full knowledge of the table it. Hints: aggregations, window functions.
- [ ] Uses `{cache: true}` if it access external services.
- [x] Naming uses a-z lowercase and hyphens.
- [x] All mandatory params cannot be made optional.
- [x] Avoids using CTEs for join operations when result is not cached.
