### PR TITLE
Dont recreate cache table on filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 Released 2016-mm-dd
 
+ - Cached tables don't get recreated when applying a filter #535.
  - Cache filter-rank analysis as it needs full knowledge of the table it.
 
 

--- a/lib/node/node.js
+++ b/lib/node/node.js
@@ -104,6 +104,10 @@ Node.prototype.id = function(skipFilters) {
     });
 };
 
+Node.prototype.cachedNodeId = function() {
+    return this.shouldCacheQuery() ? this.id(true) : this.id();
+};
+
 Node.prototype.setAttributeToModifyId = function(attr) {
     this.attributesForId.push(attr);
 };
@@ -214,7 +218,7 @@ Node.prototype.ignoreParamForId = function(paramName) {
 };
 
 Node.prototype.getTargetTable = function() {
-    return 'analysis_' + this.type.replace(/-/g, '_') + '_' + this.id(true);
+    return 'analysis_' + this.type.replace(/-/g, '_') + '_' + this.cachedNodeId();
 };
 
 Node.prototype.toJSON = function() {

--- a/lib/service/database.js
+++ b/lib/service/database.js
@@ -231,12 +231,14 @@ DatabaseService.prototype.queueAnalysisOperations = function(analysis, callback)
     var self = this;
 
     var sortedNodes = analysis.getSortedNodes();
-    var sortedNodesIds = sortedNodes.map(function(node) { return node.id(); });
+    var sortedNodesIds = sortedNodes.map(function(node) {
+        return node.cachedNodeId();
+    });
     var nodesById = analysis.getNodes().reduce(function(byId, node) {
-        if (!byId.hasOwnProperty(node.id())) {
-            byId[node.id()] = [];
+        if (!byId.hasOwnProperty(node.cachedNodeId())) {
+            byId[node.cachedNodeId()] = [];
         }
-        byId[node.id()].push(node);
+        byId[node.cachedNodeId()].push(node);
         return byId;
     }, {});
     var query = [


### PR DESCRIPTION
Cached tables don't get recreated when applying a filter, status from cached node is directly applied.

Fixes https://github.com/CartoDB/Windshaft-cartodb/issues/535.