### PR TITLE
Add geocoder provider in geocode street analysis

### DIFF
--- a/lib/node/nodes/georeference-city.js
+++ b/lib/node/nodes/georeference-city.js
@@ -7,7 +7,8 @@ var PARAMS = {
     source: Node.PARAM.NODE(Node.GEOMETRY.ANY),
     city: Node.PARAM.STRING(),
     admin_region: Node.PARAM.STRING(),
-    country: Node.PARAM.STRING()
+    country: Node.PARAM.STRING(),
+    provider: Node.PARAM.STRING()
 };
 
 var GeoreferenceCity = Node.create(TYPE, PARAMS, { cache: true });
@@ -20,16 +21,30 @@ GeoreferenceCity.prototype.sql = function() {
     return queryTemplate({
         source: this.source.getQuery(),
         columns: this.source.getColumns(true).join(', '),
-        city:this.city,
+        city: this.city,
         admin_region: this.admin_region,
-        country: this.country
+        country: this.country,
+        provider_function: getProviderFunction(this.provider)
     });
 };
+
+function getProviderFunction(providerName) {
+    switch (providerName){
+        case 'heremaps':
+            return 'cdb_here_geocode_namedplace_point';
+        case 'google':
+            return 'cdb_google_geocode_namedplace_point';
+        case 'mapzen':
+            return 'cdb_mapzen_geocode_namedplace_point';
+    default:
+        return 'cdb_geocode_namedplace_point';
+    }
+}
 
 var queryTemplate = Node.template([
     'SELECT',
     '  {{=it.columns}},',
-    '  cdb_geocode_namedplace_point(' +
+    '  {{=it.provider_function}}(' +
     '    {{=it.city}},',
     '    {{=it.admin_region}},',
     '    {{=it.country}}',

--- a/lib/node/nodes/georeference-city.js
+++ b/lib/node/nodes/georeference-city.js
@@ -8,7 +8,7 @@ var PARAMS = {
     city: Node.PARAM.STRING(),
     admin_region: Node.PARAM.STRING(),
     country: Node.PARAM.STRING(),
-    provider: Node.PARAM.STRING()
+    provider: Node.PARAM.NULLABLE(Node.PARAM.STRING(), 'mapzen')
 };
 
 var GeoreferenceCity = Node.create(TYPE, PARAMS, { cache: true });

--- a/test/fixtures/cdb_geocoder.sql
+++ b/test/fixtures/cdb_geocoder.sql
@@ -101,7 +101,43 @@ RETURNS Geometry AS $$
   END
 $$ LANGUAGE plpgsql;
 
+CREATE OR REPLACE FUNCTION cdb_mapzen_geocode_street_point(searchtext TEXT, city TEXT DEFAULT NULL, state_province TEXT DEFAULT NULL, country TEXT DEFAULT NULL)
+RETURNS Geometry AS $$
+  DECLARE
+    ret Geometry;
+  BEGIN
+    SELECT the_geom INTO ret FROM populated_places_simple WHERE cartodb_id = searchtext::integer LIMIT 1;
+
+    RETURN ret;
+  END
+$$ LANGUAGE plpgsql;
+
+
 CREATE OR REPLACE FUNCTION cdb_geocode_street_point(searchtext TEXT, city TEXT DEFAULT NULL, state_province TEXT DEFAULT NULL, country TEXT DEFAULT NULL)
+RETURNS Geometry AS $$
+  DECLARE
+    ret Geometry;
+  BEGIN
+    SELECT the_geom INTO ret FROM populated_places_simple WHERE cartodb_id = searchtext::integer LIMIT 1;
+
+    RETURN ret;
+  END
+$$ LANGUAGE plpgsql;
+
+
+CREATE OR REPLACE FUNCTION cdb_here_geocode_street_point(searchtext TEXT, city TEXT DEFAULT NULL, state_province TEXT DEFAULT NULL, country TEXT DEFAULT NULL)
+RETURNS Geometry AS $$
+  DECLARE
+    ret Geometry;
+  BEGIN
+    SELECT the_geom INTO ret FROM populated_places_simple WHERE cartodb_id = searchtext::integer LIMIT 1;
+
+    RETURN ret;
+  END
+$$ LANGUAGE plpgsql;
+
+
+CREATE OR REPLACE FUNCTION cdb_google_geocode_street_point(searchtext TEXT, city TEXT DEFAULT NULL, state_province TEXT DEFAULT NULL, country TEXT DEFAULT NULL)
 RETURNS Geometry AS $$
   DECLARE
     ret Geometry;


### PR DESCRIPTION
Not adding a new analysis but editing an existent one, so I'm ignoring the checklist below (my additions follow the naming conventions).

The node now accepts the geocoder provider as a parameter. If mapzen want to be used then `provider` should be `mapzen`. Otherwise it will use the default geocoder provider for the user.

====

For new analysis use the following checklist:

- [ ] Outputs a `the_geom geometry(Geometry, 4326)` column.
- [ ] Outputs a `cartodb_id numeric` column.
- [ ] Uses `{cache: true}` option when it needs full knowledge of the table it. Hints: aggregations, window functions.
- [ ] Uses `{cache: true}` if it access external services.
- [ ] Naming uses a-z lowercase and hyphens.
- [ ] All mandatory params cannot be made optional.
- [ ] Avoids using CTEs for join operations when result is not cached.

