### PR TITLE
Add geocoder provider in geocode street analysis and fix broken namedplaces

### DIFF
--- a/lib/node/nodes/georeference-city.js
+++ b/lib/node/nodes/georeference-city.js
@@ -7,8 +7,7 @@ var PARAMS = {
     source: Node.PARAM.NODE(Node.GEOMETRY.ANY),
     city: Node.PARAM.STRING(),
     admin_region: Node.PARAM.STRING(),
-    country: Node.PARAM.STRING(),
-    provider: Node.PARAM.NULLABLE(Node.PARAM.STRING(), 'mapzen')
+    country: Node.PARAM.STRING()
 };
 
 var GeoreferenceCity = Node.create(TYPE, PARAMS, { cache: true });
@@ -23,28 +22,14 @@ GeoreferenceCity.prototype.sql = function() {
         columns: this.source.getColumns(true).join(', '),
         city: this.city,
         admin_region: this.admin_region,
-        country: this.country,
-        provider_function: getProviderFunction(this.provider)
+        country: this.country
     });
 };
-
-function getProviderFunction(providerName) {
-    switch (providerName){
-        case 'heremaps':
-            return 'cdb_here_geocode_namedplace_point';
-        case 'google':
-            return 'cdb_google_geocode_namedplace_point';
-        case 'mapzen':
-            return 'cdb_mapzen_geocode_namedplace_point';
-    default:
-        return 'cdb_geocode_namedplace_point';
-    }
-}
 
 var queryTemplate = Node.template([
     'SELECT',
     '  {{=it.columns}},',
-    '  {{=it.provider_function}}(' +
+    '  cdb_geocode_namedplace_point(' +
     '    {{=it.city}},',
     '    {{=it.admin_region}},',
     '    {{=it.country}}',

--- a/lib/node/nodes/georeference-street-address.js
+++ b/lib/node/nodes/georeference-street-address.js
@@ -8,7 +8,12 @@ var PARAMS = {
     street_address: Node.PARAM.STRING(),
     city: Node.PARAM.NULLABLE(Node.PARAM.STRING()),
     state: Node.PARAM.NULLABLE(Node.PARAM.STRING()),
-    country: Node.PARAM.NULLABLE(Node.PARAM.STRING())
+    country: Node.PARAM.NULLABLE(Node.PARAM.STRING()),
+    provider: Node.PARAM.NULLABLE(
+        Node.PARAM.ENUM('heremaps', 'google', 'mapzen', 'user_default'),
+        'mapzen'
+    )
+
 };
 
 var GeoreferenceStreetAddress = Node.create(TYPE, PARAMS, { cache: true });
@@ -26,14 +31,30 @@ GeoreferenceStreetAddress.prototype.sql = function() {
             this.city || 'NULL',
             this.state || 'NULL',
             this.country || 'NULL'
-        ].join(', ')
+        ].join(', '),
+        provider_function: getProviderFunction(this.provider)
     });
 };
+
+function getProviderFunction(providerName) {
+    switch (providerName){
+        case 'heremaps':
+            return 'cdb_here_geocode_street_point';
+        case 'google':
+            return 'cdb_google_geocode_street_point';
+        case 'mapzen':
+             return 'cdb_mapzen_geocode_street_point';
+        case 'user_default':
+             return 'cdb_geocode_street_point';
+    default:
+        return 'cdb_geocode_street_point';
+     }
+ }
 
 var queryTemplate = Node.template([
     'SELECT',
     '  {{=it.columns}},',
-    '  cdb_geocode_street_point(' +
+    '  {{=it.provider_function}}(' +
     '    {{=it.params}}',
     '  ) AS the_geom',
     'FROM ({{=it.source}}) AS _camshaft_georeference_street_address_analysis'


### PR DESCRIPTION
See https://github.com/CartoDB/camshaft/pull/124

Yesterday I added geocoder providers... in the wrong node. It's fixed here and it's also using an ENUM for the different provider options as per https://github.com/CartoDB/camshaft/pull/124/files#r69638085.

cc @dgaubert 