### PR TITLE
Mapzen isocrones in analysis

### DIFF
--- a/lib/node/nodes/sql/trade-area-dissolved.sql
+++ b/lib/node/nodes/sql/trade-area-dissolved.sql
@@ -4,7 +4,7 @@ _cdb_analysis_source_points AS (
 ),
 _cdb_analysis_isochrones AS (
   SELECT
-    cdb_dataservices_client.cdb_isochrone(
+    cdb_dataservices_client.{{=it.provider_function}}(
       _cdb_analysis_source_points.the_geom,
       '{{=it.kind}}'::text,
       ARRAY[{{=it.isolines}}]::integer[]

--- a/lib/node/nodes/sql/trade-area.sql
+++ b/lib/node/nodes/sql/trade-area.sql
@@ -4,7 +4,7 @@ _cdb_analysis_source_points AS (
 ),
 _cdb_analysis_isochrones AS (
   SELECT
-    cdb_dataservices_client.cdb_isochrone(
+    cdb_dataservices_client.{{=it.provider_function}}(
       _cdb_analysis_source_points.the_geom,
       '{{=it.kind}}',
       ARRAY[{{=it.isolines}}]::integer[]

--- a/lib/node/nodes/trade-area.js
+++ b/lib/node/nodes/trade-area.js
@@ -11,8 +11,11 @@ var PARAMS = {
     kind: Node.PARAM.ENUM('walk', 'car'),
     time: Node.PARAM.NUMBER(),
     isolines: Node.PARAM.NUMBER(),
-    dissolved: Node.PARAM.BOOLEAN()
-};
+    dissolved: Node.PARAM.BOOLEAN(),
+    provider: Node.PARAM.NULLABLE(
+        Node.PARAM.ENUM('heremaps', 'mapzen'),
+        'mapzen'
+    )};
 
 var TradeArea = Node.create(TYPE, PARAMS, { cache: true });
 
@@ -27,7 +30,8 @@ TradeArea.prototype.sql = function() {
         pointsQuery: this.source.getQuery(),
         columnsQuery: this.source.getColumns(true).join(', '),
         kind: this.kind,
-        isolines: buildRange(this.time, this.isolines).join(', ')
+        isolines: buildRange(this.time, this.isolines).join(', '),
+        provider_function: getProviderFunction(this.provider)
     });
 };
 
@@ -48,3 +52,14 @@ function buildRange(finalValue, stepsNumber) {
 
     return range;
 }
+
+function getProviderFunction(providerName) {
+    switch (providerName){
+        case 'heremaps':
+            return 'cdb_isochrone';
+        case 'mapzen':
+             return 'cdb_mapzen_isochrone';
+    default:
+        return 'cdb_mapzen_isochrone';
+     }
+ }

--- a/lib/node/nodes/trade-area.js
+++ b/lib/node/nodes/trade-area.js
@@ -17,7 +17,7 @@ var PARAMS = {
         'mapzen'
     )};
 
-var TradeArea = Node.create(TYPE, PARAMS, { cache: true });
+var TradeArea = Node.create(TYPE, PARAMS, { cache: true, version: 2 });
 
 module.exports = TradeArea;
 module.exports.TYPE = TYPE;

--- a/test/fixtures/cdb_isochrone.sql
+++ b/test/fixtures/cdb_isochrone.sql
@@ -8,3 +8,14 @@ AS $$
     SELECT unnest($3) as radius
   ) _t
 $$ LANGUAGE 'sql' IMMUTABLE STRICT;
+
+CREATE OR REPLACE FUNCTION cdb_dataservices_client.cdb_mapzen_isochrone(center GEOMETRY, kind TEXT, range INTEGER[], OUT center geometry, OUT data_range integer, OUT the_geom geometry)
+AS $$
+  SELECT
+    $1 center,
+    _t.radius data_range,
+    ST_Buffer($1::geography, _t.radius)::geometry as the_geom
+  FROM (
+    SELECT unnest($3) as radius
+  ) _t
+$$ LANGUAGE 'sql' IMMUTABLE STRICT;


### PR DESCRIPTION
~~Do not merge yet. I'm in the process of releasing the functions included here, it won't take much but it's not ready yet.~~

Similarly to the street geocoder analysis, I'm adding providers in the trade areas one. In this scenario, we have only two providers: `heremaps` and `mapzen`. I'm setting `mapzen` as the default. Please, take into account that `mapzen` function is slower than the `heremaps` service.