### PR TITLE
Fix georeference admin region analyses

### DIFF
--- a/lib/analysis.js
+++ b/lib/analysis.js
@@ -86,7 +86,6 @@ AnalysisFactory.prototype.create = function(configuration, definition, callback)
         function analysis$finish(err, analysis) {
             if (err) {
                 if (err && err.message && err.message.match(/permission denied/i)) {
-                    console.error('>>>>>>>>>>>>>', err);
                     err = new Error('Analysis requires authentication with API key: permission denied.');
                 }
                 return callback(err);

--- a/lib/analysis.js
+++ b/lib/analysis.js
@@ -86,6 +86,7 @@ AnalysisFactory.prototype.create = function(configuration, definition, callback)
         function analysis$finish(err, analysis) {
             if (err) {
                 if (err && err.message && err.message.match(/permission denied/i)) {
+                    console.error('>>>>>>>>>>>>>', err);
                     err = new Error('Analysis requires authentication with API key: permission denied.');
                 }
                 return callback(err);

--- a/lib/node/nodes/georeference-admin-region.js
+++ b/lib/node/nodes/georeference-admin-region.js
@@ -6,7 +6,7 @@ var TYPE = 'georeference-admin-region';
 var PARAMS = {
     source: Node.PARAM.NODE(Node.GEOMETRY.ANY),
     admin_region: Node.PARAM.STRING(),
-    country: Node.PARAM.STRING()
+    country: Node.PARAM.NULLABLE(Node.PARAM.STRING())
 };
 
 var GeoreferenceAdminRegion = Node.create(TYPE, PARAMS, { cache: true });
@@ -16,12 +16,18 @@ module.exports.TYPE = TYPE;
 module.exports.PARAMS = PARAMS;
 
 GeoreferenceAdminRegion.prototype.sql = function() {
+    var geocoderParams = [this.admin_region];
+
+    if (this.country) {
+        geocoderParams.push(this.country);
+    }
+
     return queryTemplate({
         source: this.source.getQuery(),
         columns: this.source.getColumns(true).join(', '),
-        city:this.city,
-        admin_region: this.admin_region,
-        country: this.country
+        geocoder_params: geocoderParams.map(function (param) {
+            return '\'' + param + '\'';
+        }).join(', ')
     });
 };
 
@@ -29,8 +35,7 @@ var queryTemplate = Node.template([
     'SELECT',
     '  {{=it.columns}},',
     '  cdb_dataservices_client.cdb_geocode_admin1_polygon(' +
-    '    {{=it.admin_region}},',
-    '    {{=it.country}}',
+    '    {{=it.geocoder_params}}',
     '  ) AS the_geom',
     'FROM ({{=it.source}}) AS _camshaft_georeference_admin_region_analysis'
  ].join('\n'));

--- a/lib/node/nodes/georeference-admin-region.js
+++ b/lib/node/nodes/georeference-admin-region.js
@@ -5,7 +5,7 @@ var Node = require('../node');
 var TYPE = 'georeference-admin-region';
 var PARAMS = {
     source: Node.PARAM.NODE(Node.GEOMETRY.ANY),
-    admin_region: Node.PARAM.STRING(),
+    admin_region: Node.PARAM.NULLABLE(Node.PARAM.STRING()),
     country: Node.PARAM.NULLABLE(Node.PARAM.STRING())
 };
 
@@ -16,15 +16,27 @@ module.exports.TYPE = TYPE;
 module.exports.PARAMS = PARAMS;
 
 GeoreferenceAdminRegion.prototype.sql = function() {
-    var geocoderParams = [this.admin_region];
+    var geocoderFunction = '';
+    var geocoderParams = [];
 
-    if (this.country) {
+    if (this.country && !this.admin_region) {
+        // country geocoder
+        geocoderFunction = 'cdb_geocode_admin0_polygon';
         geocoderParams.push(this.country);
+    } else {
+        // adm. region geocoder
+        geocoderFunction = 'cdb_geocode_admin1_polygon';
+        geocoderParams.push(this.admin_region);
+
+        if (this.country) {
+            geocoderParams.push(this.country);
+        }
     }
 
     return queryTemplate({
         source: this.source.getQuery(),
         columns: this.source.getColumns(true).join(', '),
+        geocoder_function: geocoderFunction,
         geocoder_params: geocoderParams.map(function (param) {
             return '\'' + param + '\'';
         }).join(', ')
@@ -34,7 +46,7 @@ GeoreferenceAdminRegion.prototype.sql = function() {
 var queryTemplate = Node.template([
     'SELECT',
     '  {{=it.columns}},',
-    '  cdb_dataservices_client.cdb_geocode_admin1_polygon(' +
+    '  cdb_dataservices_client.{{=it.geocoder_function}}(' +
     '    {{=it.geocoder_params}}',
     '  ) AS the_geom',
     'FROM ({{=it.source}}) AS _camshaft_georeference_admin_region_analysis'

--- a/lib/node/nodes/georeference-admin-region.js
+++ b/lib/node/nodes/georeference-admin-region.js
@@ -1,12 +1,14 @@
 'use strict';
 
 var Node = require('../node');
+var debug = require('../../util/debug')('analysis:georeference-admin-region');
 
 var TYPE = 'georeference-admin-region';
 var PARAMS = {
     source: Node.PARAM.NODE(Node.GEOMETRY.ANY),
-    admin_region: Node.PARAM.NULLABLE(Node.PARAM.STRING()),
-    country: Node.PARAM.NULLABLE(Node.PARAM.STRING())
+    admin_region_column: Node.PARAM.STRING(),
+    country: Node.PARAM.NULLABLE(Node.PARAM.STRING()),
+    country_column: Node.PARAM.NULLABLE(Node.PARAM.STRING())
 };
 
 var GeoreferenceAdminRegion = Node.create(TYPE, PARAMS, { cache: true });
@@ -16,37 +18,42 @@ module.exports.TYPE = TYPE;
 module.exports.PARAMS = PARAMS;
 
 GeoreferenceAdminRegion.prototype.sql = function() {
-    var geocoderFunction = '';
-    var geocoderParams = [];
-
-    if (this.country && !this.admin_region) {
-        // country geocoder
-        geocoderFunction = 'cdb_geocode_admin0_polygon';
-        geocoderParams.push(this.country);
-    } else {
-        // adm. region geocoder
-        geocoderFunction = 'cdb_geocode_admin1_polygon';
-        geocoderParams.push(this.admin_region);
-
-        if (this.country) {
-            geocoderParams.push(this.country);
-        }
-    }
-
-    return queryTemplate({
+    var sql = queryTemplate({
         source: this.source.getQuery(),
         columns: this.source.getColumns(true).join(', '),
-        geocoder_function: geocoderFunction,
-        geocoder_params: geocoderParams.map(function (param) {
-            return '\'' + param + '\'';
-        }).join(', ')
+        geocoder_params: this.getGeocoderParams().join(', ')
     });
+
+    debug(sql);
+
+    return sql;
+};
+
+GeoreferenceAdminRegion.prototype.getGeocoderParams = function () {
+    var geocoderParams = [];
+
+    geocoderParams.push(this.getFunctionParam('admin_region'));
+    if (this.getFunctionParam('country')) {
+        geocoderParams.push(this.getFunctionParam('country'));
+    }
+
+    return geocoderParams;
+};
+
+GeoreferenceAdminRegion.prototype.getFunctionParam = function (name) {
+    if (this[name + '_column']) {
+        return this[name + '_column'];
+    }
+
+    if (this[name]) {
+        return '\'' + this[name] + '\'';
+    }
 };
 
 var queryTemplate = Node.template([
     'SELECT',
     '  {{=it.columns}},',
-    '  cdb_dataservices_client.{{=it.geocoder_function}}(' +
+    '  cdb_dataservices_client.cdb_geocode_admin1_polygon(' +
     '    {{=it.geocoder_params}}',
     '  ) AS the_geom',
     'FROM ({{=it.source}}) AS _camshaft_georeference_admin_region_analysis'

--- a/lib/node/nodes/georeference-city.js
+++ b/lib/node/nodes/georeference-city.js
@@ -6,8 +6,8 @@ var TYPE = 'georeference-city';
 var PARAMS = {
     source: Node.PARAM.NODE(Node.GEOMETRY.ANY),
     city: Node.PARAM.STRING(),
-    admin_region: Node.PARAM.STRING(),
-    country: Node.PARAM.STRING()
+    admin_region: Node.PARAM.NULLABLE(Node.PARAM.STRING()),
+    country: Node.PARAM.NULLABLE(Node.PARAM.STRING())
 };
 
 var GeoreferenceCity = Node.create(TYPE, PARAMS, { cache: true });
@@ -17,12 +17,22 @@ module.exports.TYPE = TYPE;
 module.exports.PARAMS = PARAMS;
 
 GeoreferenceCity.prototype.sql = function() {
+    var geocoderParams = [this.city];
+
+    if (this.admin_region) {
+        geocoderParams.push(this.admin_region);
+    }
+
+    if (this.country) {
+        geocoderParams.push(this.country);
+    }
+
     return queryTemplate({
         source: this.source.getQuery(),
         columns: this.source.getColumns(true).join(', '),
-        city: this.city,
-        admin_region: this.admin_region,
-        country: this.country
+        geocoder_params: geocoderParams.map(function (param) {
+            return '\'' + param + '\'';
+        }).join(', ')
     });
 };
 
@@ -30,9 +40,7 @@ var queryTemplate = Node.template([
     'SELECT',
     '  {{=it.columns}},',
     '  cdb_dataservices_client.cdb_geocode_namedplace_point(' +
-    '    {{=it.city}},',
-    '    {{=it.admin_region}},',
-    '    {{=it.country}}',
+    '    {{=it.geocoder_params}}',
     '  ) AS the_geom',
     'FROM ({{=it.source}}) AS _camshaft_georeference_city_analysis'
  ].join('\n'));

--- a/lib/node/nodes/georeference-country.js
+++ b/lib/node/nodes/georeference-country.js
@@ -6,7 +6,7 @@ var debug = require('../../util/debug')('analysis:georeference-country');
 var TYPE = 'georeference-country';
 var PARAMS = {
     source: Node.PARAM.NODE(Node.GEOMETRY.ANY),
-    country: Node.PARAM.STRING()
+    country_column: Node.PARAM.STRING()
 };
 
 var GeoreferenceCountry = Node.create(TYPE, PARAMS, {
@@ -21,7 +21,7 @@ GeoreferenceCountry.prototype.sql = function() {
     var sql = queryTemplate({
         source: this.source.getQuery(),
         columns: this.source.getColumns(true).join(', '),
-        country: this.country
+        country: this.country_column
     });
 
     debug(sql);

--- a/lib/node/nodes/georeference-country.js
+++ b/lib/node/nodes/georeference-country.js
@@ -1,0 +1,37 @@
+'use strict';
+
+var Node = require('../node');
+var debug = require('../../util/debug')('analysis:georeference-country');
+
+var TYPE = 'georeference-country';
+var PARAMS = {
+    source: Node.PARAM.NODE(Node.GEOMETRY.ANY),
+    country: Node.PARAM.STRING()
+};
+
+var GeoreferenceCountry = Node.create(TYPE, PARAMS, {
+    cache: true
+});
+
+module.exports = GeoreferenceCountry;
+module.exports.TYPE = TYPE;
+module.exports.PARAMS = PARAMS;
+
+GeoreferenceCountry.prototype.sql = function() {
+    var sql = queryTemplate({
+        source: this.source.getQuery(),
+        columns: this.source.getColumns(true).join(', '),
+        country: this.country
+    });
+
+    debug(sql);
+
+    return sql;
+};
+
+var queryTemplate = Node.template([
+    'SELECT',
+    '  {{=it.columns}},',
+    '  cdb_dataservices_client.cdb_geocode_admin0_polygon({{=it.country}}) AS the_geom',
+    'FROM ({{=it.source}}) AS _camshaft_georeference_admin_region_analysis'
+ ].join('\n'));


### PR DESCRIPTION
Fixes ##128 and #138 partially: 
 - Extract `georeference-country` analysis from `georeference-admin-region`.
 - Added `country_column` param to be used as column value and keeps `country` to be used as custom text in `georeference-admin-region analysis`.