### PR TITLE
Fixes geocoder street params

### DIFF
--- a/lib/node/nodes/georeference-street-address.js
+++ b/lib/node/nodes/georeference-street-address.js
@@ -13,7 +13,6 @@ var PARAMS = {
         Node.PARAM.ENUM('heremaps', 'google', 'mapzen', 'user_default'),
         'mapzen'
     )
-
 };
 
 var GeoreferenceStreetAddress = Node.create(TYPE, PARAMS, { cache: true });
@@ -23,16 +22,20 @@ module.exports.TYPE = TYPE;
 module.exports.PARAMS = PARAMS;
 
 GeoreferenceStreetAddress.prototype.sql = function() {
+    var geocoderParams = [
+        this.street_address,
+        this.city,
+        this.state,
+        this.country
+    ];
+
     return queryTemplate({
         source: this.source.getQuery(),
         columns: this.source.getColumns(true).join(', '),
-        params: [
-            this.street_address,
-            this.city || 'NULL',
-            this.state || 'NULL',
-            this.country || 'NULL'
-        ].join(', '),
-        provider_function: getProviderFunction(this.provider)
+        provider_function: getProviderFunction(this.provider),
+        params: geocoderParams.map(function (param) {
+            return param ? '\'' + param + '\'' : 'NULL';
+        }).join(', ')
     });
 };
 

--- a/lib/node/nodes/georeference-street-address.js
+++ b/lib/node/nodes/georeference-street-address.js
@@ -1,14 +1,18 @@
 'use strict';
 
 var Node = require('../node');
+var debug = require('../../util/debug')('analysis:georeference-street-address');
 
 var TYPE = 'georeference-street-address';
 var PARAMS = {
     source: Node.PARAM.NODE(Node.GEOMETRY.ANY),
     street_address: Node.PARAM.STRING(),
     city: Node.PARAM.NULLABLE(Node.PARAM.STRING()),
+    city_column: Node.PARAM.NULLABLE(Node.PARAM.STRING()),
     state: Node.PARAM.NULLABLE(Node.PARAM.STRING()),
+    state_column: Node.PARAM.NULLABLE(Node.PARAM.STRING()),
     country: Node.PARAM.NULLABLE(Node.PARAM.STRING()),
+    country_column: Node.PARAM.NULLABLE(Node.PARAM.STRING()),
     provider: Node.PARAM.NULLABLE(
         Node.PARAM.ENUM('heremaps', 'google', 'mapzen', 'user_default'),
         'mapzen'
@@ -24,19 +28,33 @@ module.exports.PARAMS = PARAMS;
 GeoreferenceStreetAddress.prototype.sql = function() {
     var geocoderParams = [
         this.street_address,
-        this.city,
-        this.state,
-        this.country
+        this.getFunctionParam('city'),
+        this.getFunctionParam('state'),
+        this.getFunctionParam('country')
     ];
 
-    return queryTemplate({
+    var sql = queryTemplate({
         source: this.source.getQuery(),
         columns: this.source.getColumns(true).join(', '),
         provider_function: getProviderFunction(this.provider),
-        params: geocoderParams.map(function (param) {
-            return param ? '\'' + param + '\'' : 'NULL';
-        }).join(', ')
+        params: geocoderParams.join(', ')
     });
+
+    debug(sql);
+
+    return sql;
+};
+
+GeoreferenceStreetAddress.prototype.getFunctionParam = function (name) {
+    if (this[name + '_column']) {
+        return this[name + '_column'];
+    }
+
+    if (this[name]) {
+        return '\'' + this[name] + '\'';
+    }
+
+    return 'NULL';
 };
 
 function getProviderFunction(providerName) {


### PR DESCRIPTION
Fixes #137 and #138 partially:
 - Added params to `georeference-street-address` to define if a param is a custom text or a column value.