### PR TITLE
Freeze last updated time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Released 2016-mm-dd
 
+ - Freeze last updated time for queries/tables not found by CDB_QueryTables_Updated_At #143.
+
 
 ## 0.38.1
 

--- a/lib/service/database.js
+++ b/lib/service/database.js
@@ -68,7 +68,7 @@ DatabaseService.prototype.getLastUpdatedTimeFromAffectedTables = function(node, 
             return callback(err);
         }
 
-        var defaultLastUpdatedTime = new Date();
+        var defaultLastUpdatedTime = new Date('1970-01-01T00:00:00.000Z');
         var rows = resultSet.rows || [defaultLastUpdatedTime];
         var lastUpdatedTimeFromAffectedTables = (rows[0] && rows[0].max) || defaultLastUpdatedTime;
 

--- a/test/fixtures/cdb_dataservices_client/obs_getmeasure.sql
+++ b/test/fixtures/cdb_dataservices_client/obs_getmeasure.sql
@@ -9,7 +9,7 @@ BEGIN
 END;
 $$  LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION OBS_GetMeasure(
+CREATE OR REPLACE FUNCTION cdb_dataservices_client.OBS_GetMeasure(
   geom geometry,
   segment_name text,
   denominator text

--- a/test/fixtures/cdb_querytables_updated_at.sql
+++ b/test/fixtures/cdb_querytables_updated_at.sql
@@ -1,5 +1,12 @@
 CREATE OR REPLACE FUNCTION CDB_QueryTables_Updated_At(query text)
     RETURNS TABLE(dbname text, schema_name text, table_name text, updated_at timestamptz)
 AS $$
-    SELECT 'analysis_api_test_db'::text, 'public'::text, 'table_name'::text, '2016-07-01 11:40:05.699712+00'::timestamptz
+    SELECT
+    'analysis_api_test_db'::text,
+    'public'::text,
+    'table_name'::text,
+    CASE WHEN position('nulltime' in query) > 0
+        THEN null::timestamptz
+        ELSE '2016-07-01 11:40:05.699712+00'::timestamptz
+    END
 $$ LANGUAGE SQL;

--- a/test/integration/database-service.js
+++ b/test/integration/database-service.js
@@ -1,0 +1,38 @@
+'use strict';
+
+var assert = require('assert');
+
+var Source = require('../../lib/node/nodes/source');
+
+var DatabaseService = require('../../lib/service/database');
+var testConfig = require('../test-config');
+
+describe('database-servie', function() {
+
+    var SKIP = true;
+    var QUERY_QUERYTABLES = 'select * from atm_machines';
+    var QUERY_NO_QUERYTABLES = 'select * from nulltime';
+
+    before(function() {
+        this.databaseService = new DatabaseService(testConfig.user, testConfig.db, testConfig.batch);
+    });
+
+    it('should return time from CDB_QueryTables_Updated_At', function(done) {
+        var source = new Source(testConfig.user, { query: QUERY_QUERYTABLES });
+        this.databaseService.getLastUpdatedTimeFromAffectedTables(source, !SKIP, function(err, lastUpdatedTime) {
+            assert.ok(!err, err);
+            assert.equal(lastUpdatedTime.getTime(), new Date('2016-07-01T11:40:05.699Z').getTime());
+            done();
+        });
+    });
+
+    it('should return a fixed time in the past for tables not found by CDB_QueryTables_Updated_At', function(done) {
+        var source = new Source(testConfig.user, { query: QUERY_NO_QUERYTABLES });
+        this.databaseService.getLastUpdatedTimeFromAffectedTables(source, !SKIP, function(err, lastUpdatedTime) {
+            assert.ok(!err, err);
+            assert.equal(lastUpdatedTime.getTime(), new Date('1970-01-01T00:00:00.000Z').getTime());
+            done();
+        });
+    });
+
+});


### PR DESCRIPTION
Freeze last updated time for queries/tables not found by CDB_QueryTables_Updated_At.

Closes #143.