### PR TITLE
Add closest features finding

### DIFF
--- a/lib/node/nodes/closest.js
+++ b/lib/node/nodes/closest.js
@@ -1,0 +1,46 @@
+'use strict';
+
+var Node = require('../node');
+
+var TYPE = 'closest';
+
+var PARAMS = {
+    source: Node.PARAM.NODE(Node.GEOMETRY.ANY),
+    target: Node.PARAM.NODE(Node.GEOMETRY.ANY)
+};
+
+var Closest = Node.create(TYPE, PARAMS, {cache: true, version: 1});
+
+module.exports = Closest;
+module.exports.TYPE = TYPE;
+module.exports.PARAMS = PARAMS;
+
+var closestTemplate = Node.template([
+    'WITH',
+    ' source as({{=it.squery}}),',
+    ' target as({{=it.tquery}})',
+    'SELECT',
+    ' s.*,',
+    ' t.cartodb_id as closest_id,',
+    ' ST_Distance(geography(t.the_geom),',
+    ' geography(s.the_geom)) as closest_dist',
+    'FROM',
+    '(',
+        'SELECT DISTINCT ON (the_geom) *',
+        ' FROM source',
+    ') AS s',
+    'CROSS JOIN LATERAL',
+    '(',
+        'SELECT cartodb_id, the_geom',
+        ' FROM target',
+        ' ORDER BY s.the_geom_webmercator <-> the_geom_webmercator',
+        ' LIMIT 1',
+    ') AS t'
+].join('\n'));
+
+Closest.prototype.sql = function(){
+    return closestTemplate({
+        squery: this.source.getQuery(),
+        tquery: this.target.getQuery()
+    });
+};


### PR DESCRIPTION
Answer to this feature request: https://github.com/CartoDB/crankshaft/issues/85

For new analysis use the following checklist:

- [x] Outputs a `the_geom geometry(Geometry, 4326)` column.
- [x] Outputs a `cartodb_id numeric` column.
- [x] Uses `{cache: true}` option when it needs full knowledge of the table it. Hints: aggregations, window functions.
- [x] Uses `{cache: true}` if it access external services.
- [x] Naming uses a-z lowercase and hyphens.
- [x] All mandatory params cannot be made optional.
- [x] Avoids using CTEs for join operations when result is not cached.

