### PR TITLE
Check cached tables limits

### DIFF
--- a/lib/service/database.js
+++ b/lib/service/database.js
@@ -224,6 +224,10 @@ function populateCacheTableQuery(targetTableName, outputQuery) {
     return 'INSERT INTO ' + targetTableName + ' ' + outputQuery;
 }
 
+function checkCacheTableQuery(targetTableName) {
+    return 'SELECT CDB_CheckAnalysisQuota(\'' + targetTableName + '\')';
+}
+
 function updateNodeAtAnalysisCatalogQuery(nodeIds, columns) {
     nodeIds = Array.isArray(nodeIds) ? nodeIds : [nodeIds];
     return [
@@ -294,7 +298,8 @@ DatabaseService.prototype.queueAnalysisOperations = function(analysis, callback)
                     id: asyncQueryId(analysis, nodeToUpdate),
                     query: transactionQuery([
                         deleteFromCacheTableQuery(targetTableName),
-                        populateCacheTableQuery(targetTableName, nodeToUpdate.sql())
+                        populateCacheTableQuery(targetTableName, nodeToUpdate.sql()),
+                        checkCacheTableQuery(targetTableName)
                     ]),
                     onsuccess: updateNodeAtAnalysisCatalogForJobResultQuery(nodeIds, Node.STATUS.READY),
                     onerror: updateNodeAtAnalysisCatalogForJobResultQuery(nodeIds, Node.STATUS.FAILED, true)

--- a/test/fixtures/cdb_analysischeck.sql
+++ b/test/fixtures/cdb_analysischeck.sql
@@ -1,0 +1,6 @@
+CREATE OR REPLACE FUNCTION CDB_CheckAnalysisQuota(table_name TEXT)
+RETURNS void AS
+$$
+BEGIN
+END;
+$$ LANGUAGE PLPGSQL;

--- a/test/setup.js
+++ b/test/setup.js
@@ -17,6 +17,7 @@ before(function setupTestDatabase(done) {
         fs.realpathSync('./test/fixtures/postgis_extension.sql'),
         fs.realpathSync('./test/fixtures/cdb_querytables_updated_at.sql'),
         fs.realpathSync('./test/fixtures/cdb_analysis_catalog.sql'),
+        fs.realpathSync('./test/fixtures/cdb_analysischeck.sql'),
 
         fs.realpathSync('./test/fixtures/cdb_dataservices_client/schema.sql'),
         fs.realpathSync('./test/fixtures/cdb_dataservices_client/cdb_geocoder.sql'),


### PR DESCRIPTION
⚠️  This requires a new version of the cartodb extension that includes a new function: https://github.com/CartoDB/cartodb-postgresql/pull/280
(so the extension must be deployed before this or all analysis will fail!!)

See #206

Each time a cache table is populted a function CDB_CheckAnalysisQuota from the cartodb extension is used to check if the limits for cached analysis tables have been exceeded, aborting the analysis in that case.

CDB_CheckAnalysisQuota raises an exception if the limits are exceeded. The message from this exception will be set to the node.