### PR TITLE
use meters instead of kms

### DIFF
--- a/lib/node/nodes/sql/line-source-to-target-closest.sql
+++ b/lib/node/nodes/sql/line-source-to-target-closest.sql
@@ -1,6 +1,6 @@
 SELECT
   *,
-  ST_Length(the_geom::geography) / 1000 AS length
+  ST_Length(the_geom::geography) AS length
 FROM (
   SELECT
     {{=it.target_alias}}.cartodb_id as closest_id,


### PR DESCRIPTION
ST_Length(the_geom::geography) returns meters, I don't think we need to use km, what do you think?
