### PR TITLE
Fix bug affecting line-sequential limits

### DIFF
--- a/lib/node/limits.js
+++ b/lib/node/limits.js
@@ -82,7 +82,7 @@ function limitInputRowsAndAvgGroupedRows(node, input, column, context, lims, cal
                 );
              }
              else {
-               check(inputRows.source, numCategories);
+               check(inputRows, numCategories);
              }
         }
     });


### PR DESCRIPTION
This prevents the limits to be applied to line-sequential when not grouping by any column