### PR TITLE
Use DS exception safe API functions

### DIFF
--- a/lib/node/nodes/georeference-admin-region.js
+++ b/lib/node/nodes/georeference-admin-region.js
@@ -52,7 +52,7 @@ GeoreferenceAdminRegion.prototype.getFunctionParam = function (name) {
 var queryTemplate = Node.template([
     'SELECT',
     '  {{=it.columns}},',
-    '  cdb_dataservices_client.cdb_geocode_admin1_polygon(' +
+    '  cdb_dataservices_client._cdb_geocode_admin1_polygon_exception_safe(' +
     '    {{=it.geocoder_params}}',
     '  ) AS the_geom',
     'FROM ({{=it.source}}) AS _camshaft_georeference_admin_region_analysis'

--- a/lib/node/nodes/georeference-city.js
+++ b/lib/node/nodes/georeference-city.js
@@ -65,7 +65,7 @@ GeoreferenceCity.prototype.getFunctionParam = function (name) {
 var queryTemplate = Node.template([
     'SELECT',
     '  {{=it.columns}},',
-    '  cdb_dataservices_client.cdb_geocode_namedplace_point(' +
+    '  cdb_dataservices_client._cdb_geocode_namedplace_point_exception_safe(' +
     '    {{=it.geocoder_params}}',
     '  ) AS the_geom',
     'FROM ({{=it.source}}) AS _camshaft_georeference_city_analysis'

--- a/lib/node/nodes/georeference-country.js
+++ b/lib/node/nodes/georeference-country.js
@@ -31,7 +31,7 @@ GeoreferenceCountry.prototype.sql = function() {
 var queryTemplate = Node.template([
     'SELECT',
     '  {{=it.columns}},',
-    '  cdb_dataservices_client.cdb_geocode_admin0_polygon({{=it.country}}) AS the_geom',
+    '  cdb_dataservices_client._cdb_geocode_admin0_polygon_exception_safe({{=it.country}}) AS the_geom',
     'FROM ({{=it.source}}) AS _camshaft_georeference_country_analysis'
  ].join('\n'));
 

--- a/lib/node/nodes/georeference-ip-address.js
+++ b/lib/node/nodes/georeference-ip-address.js
@@ -23,7 +23,7 @@ GeoreferenceIpAddress.prototype.sql = function() {
 var queryTemplate = Node.template([
     'SELECT',
     '  {{=it.columns}},',
-    '  cdb_dataservices_client.cdb_geocode_ipaddress_point(' +
+    '  cdb_dataservices_client._cdb_geocode_ipaddress_point_exception_safe(' +
     '    {{=it.ip_address}}',
     '  ) AS the_geom',
     'FROM ({{=it.source}}) AS _camshaft_georeference_ip_address_analysis'

--- a/lib/node/nodes/georeference-postal-code.js
+++ b/lib/node/nodes/georeference-postal-code.js
@@ -62,11 +62,11 @@ GeoreferencePostalCode.prototype.getFunctionParam = function (name) {
 function getGecoderFunction(geometryType) {
     switch (geometryType){
         case Node.GEOMETRY.POLYGON:
-            return 'cdb_geocode_postalcode_polygon';
+            return '_cdb_geocode_postalcode_polygon_exception_safe';
         case Node.GEOMETRY.POINT:
-            return 'cdb_geocode_postalcode_point';
+            return '_cdb_geocode_postalcode_point_exception_safe';
     default:
-        return 'cdb_geocode_postalcode_point';
+        return '_cdb_geocode_postalcode_point_exception_safe';
      }
 }
 
@@ -82,7 +82,7 @@ var queryTemplate = Node.template([
  GeoreferencePostalCode.prototype.checkLimits = function(context, callback) {
      var defaultLimit;
      var limitName;
-     if (getGecoderFunction(this.output_geometry_type) === 'cdb_geocode_postalcode_polygon') {
+     if (getGecoderFunction(this.output_geometry_type) === '_cdb_geocode_postalcode_polygon_exception_safe') {
          defaultLimit = 10000;
          limitName = 'maximumNumberOfRowsPolygon';
      }

--- a/lib/node/nodes/georeference-street-address.js
+++ b/lib/node/nodes/georeference-street-address.js
@@ -58,7 +58,7 @@ GeoreferenceStreetAddress.prototype.getFunctionParam = function (name) {
 var queryTemplate = Node.template([
     'SELECT',
     '  {{=it.columns}},',
-    '  cdb_dataservices_client.cdb_geocode_street_point(' +
+    '  cdb_dataservices_client._cdb_geocode_street_point_exception_safe(' +
     '    {{=it.params}}',
     '  ) AS the_geom',
     'FROM ({{=it.source}}) AS _camshaft_georeference_street_address_analysis'

--- a/lib/node/nodes/routing-sequential.js
+++ b/lib/node/nodes/routing-sequential.js
@@ -36,7 +36,7 @@ var routingSequentialQueryTemplate = Node.template([
     '  (route).the_geom',
     'FROM (',
     '  SELECT',
-    '    cdb_dataservices_client.cdb_route_with_waypoints(',
+    '    cdb_dataservices_client._cdb_route_with_waypoints_exception_safe(',
     '      array_agg({{=it.column_target}}),',
     '      \'{{=it.mode}}\',',
     '      ARRAY[\'mode_type={{=it.mode_type}}\']::text[],',

--- a/lib/node/nodes/routing-to-layer-all-to-all.js
+++ b/lib/node/nodes/routing-to-layer-all-to-all.js
@@ -67,7 +67,7 @@ var routingToLayerQueryTemplate = Node.template([
     '  {{=it.final_columns}}',
     'FROM (',
     '  SELECT',
-    '    cdb_dataservices_client.cdb_route_point_to_point(',
+    '    cdb_dataservices_client._cdb_route_point_to_point_exception_safe(',
     '      _cdb_analysis_source.the_geom,',
     '      _cdb_analysis_target.the_geom,',
     '      \'{{=it.mode}}\',',

--- a/lib/node/nodes/routing-to-single-point.js
+++ b/lib/node/nodes/routing-to-single-point.js
@@ -35,7 +35,7 @@ var routingToSinglePointQueryTemplate = Node.template([
     '  {{=it.columns}}',
     'FROM (',
     '  SELECT',
-    '    cdb_dataservices_client.cdb_route_point_to_point(',
+    '    cdb_dataservices_client._cdb_route_point_to_point_exception_safe(',
     '      the_geom,',
     '      ST_SetSRID(',
     '        ST_MakePoint(',

--- a/lib/node/nodes/sql/trade-area-dissolved.sql
+++ b/lib/node/nodes/sql/trade-area-dissolved.sql
@@ -4,7 +4,7 @@ _cdb_analysis_source_points AS (
 ),
 _cdb_analysis_isochrones AS (
   SELECT
-    cdb_dataservices_client.cdb_isochrone(
+    cdb_dataservices_client._cdb_isochrone_exception_safe(
       _cdb_analysis_source_points.the_geom,
       '{{=it.kind}}'::text,
       ARRAY[{{=it.isolines}}]::integer[]

--- a/lib/node/nodes/sql/trade-area.sql
+++ b/lib/node/nodes/sql/trade-area.sql
@@ -4,7 +4,7 @@ _cdb_analysis_source_points AS (
 ),
 _cdb_analysis_isochrones AS (
   SELECT
-    cdb_dataservices_client.cdb_isochrone(
+    cdb_dataservices_client._cdb_isochrone_exception_safe(
       _cdb_analysis_source_points.the_geom,
       '{{=it.kind}}',
       ARRAY[{{=it.isolines}}]::integer[]

--- a/test/fixtures/cdb_dataservices_client/cdb_geocoder.sql
+++ b/test/fixtures/cdb_dataservices_client/cdb_geocoder.sql
@@ -1,5 +1,5 @@
----- cdb_geocode_namedplace_point(city_name text, admin1_name text, country_name text)
-CREATE OR REPLACE FUNCTION cdb_dataservices_client.cdb_geocode_namedplace_point(city_name text, admin1_name text, country_name text)
+---- _cdb_geocode_namedplace_point_exception_safe(city_name text, admin1_name text, country_name text)
+CREATE OR REPLACE FUNCTION cdb_dataservices_client._cdb_geocode_namedplace_point_exception_safe(city_name text, admin1_name text, country_name text)
 RETURNS Geometry AS $$
   DECLARE
     ret Geometry;
@@ -12,8 +12,8 @@ RETURNS Geometry AS $$
   END
 $$ LANGUAGE plpgsql;
 
----- cdb_geocode_admin1_polygon(admin1_name text, country_name text)
-CREATE OR REPLACE FUNCTION cdb_dataservices_client.cdb_geocode_admin1_polygon(admin1_name text, country_name text)
+---- _cdb_geocode_admin1_polygon_exception_safe(admin1_name text, country_name text)
+CREATE OR REPLACE FUNCTION cdb_dataservices_client._cdb_geocode_admin1_polygon_exception_safe(admin1_name text, country_name text)
 RETURNS Geometry AS $$
   DECLARE
     ret Geometry;
@@ -37,8 +37,8 @@ RETURNS Geometry AS $$
   END
 $$ LANGUAGE plpgsql;
 
----- cdb_geocode_postalcode_polygon(postal_code text, country_name text)
-CREATE OR REPLACE FUNCTION cdb_dataservices_client.cdb_geocode_postalcode_polygon(postal_code text, country_name text)
+---- _cdb_geocode_postalcode_polygon_exception_safe(postal_code text, country_name text)
+CREATE OR REPLACE FUNCTION cdb_dataservices_client._cdb_geocode_postalcode_polygon_exception_safe(postal_code text, country_name text)
 RETURNS Geometry AS $$
   DECLARE
     ret Geometry;
@@ -62,8 +62,8 @@ RETURNS Geometry AS $$
   END
 $$ LANGUAGE plpgsql;
 
----- cdb_geocode_ipaddress_point(ip text)
-CREATE OR REPLACE FUNCTION cdb_dataservices_client.cdb_geocode_ipaddress_point(ip text)
+---- _cdb_geocode_ipaddress_point_exception_safe(ip text)
+CREATE OR REPLACE FUNCTION cdb_dataservices_client._cdb_geocode_ipaddress_point_exception_safe(ip text)
 RETURNS Geometry AS $$
   DECLARE
     i INTEGER := 0;
@@ -101,7 +101,7 @@ RETURNS Geometry AS $$
   END
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION cdb_dataservices_client.cdb_geocode_street_point(searchtext TEXT, city TEXT DEFAULT NULL, state_province TEXT DEFAULT NULL, country TEXT DEFAULT NULL)
+CREATE OR REPLACE FUNCTION cdb_dataservices_client._cdb_geocode_street_point_exception_safe(searchtext TEXT, city TEXT DEFAULT NULL, state_province TEXT DEFAULT NULL, country TEXT DEFAULT NULL)
 RETURNS Geometry AS $$
   DECLARE
     ret Geometry;

--- a/test/fixtures/cdb_dataservices_client/cdb_isochrone.sql
+++ b/test/fixtures/cdb_dataservices_client/cdb_isochrone.sql
@@ -1,4 +1,4 @@
-CREATE OR REPLACE FUNCTION cdb_dataservices_client.cdb_isochrone(center GEOMETRY, kind TEXT, range INTEGER[], OUT center geometry, OUT data_range integer, OUT the_geom geometry)
+CREATE OR REPLACE FUNCTION cdb_dataservices_client._cdb_isochrone_exception_safe(center GEOMETRY, kind TEXT, range INTEGER[], OUT center geometry, OUT data_range integer, OUT the_geom geometry)
 AS $$
   SELECT
     $1 center,

--- a/test/fixtures/cdb_dataservices_client/cdb_route_point_to_point.sql
+++ b/test/fixtures/cdb_dataservices_client/cdb_route_point_to_point.sql
@@ -1,4 +1,4 @@
-CREATE OR REPLACE FUNCTION cdb_dataservices_client.cdb_route_point_to_point(origin GEOMETRY, destination GEOMETRY, mode TEXT, options TEXT[], units TEXT, OUT duration integer, OUT length real, OUT the_geom geometry)
+CREATE OR REPLACE FUNCTION cdb_dataservices_client._cdb_route_point_to_point_exception_safe(origin GEOMETRY, destination GEOMETRY, mode TEXT, options TEXT[], units TEXT, OUT duration integer, OUT length real, OUT the_geom geometry)
 AS $$
   SELECT
     trunc(random() * 1000)::integer duration,

--- a/test/fixtures/cdb_dataservices_client/cdb_route_with_waypoints.sql
+++ b/test/fixtures/cdb_dataservices_client/cdb_route_with_waypoints.sql
@@ -1,4 +1,4 @@
-CREATE OR REPLACE FUNCTION cdb_dataservices_client.cdb_route_with_waypoints(
+CREATE OR REPLACE FUNCTION cdb_dataservices_client._cdb_route_with_waypoints_exception_safe(
   waypoints geometry(Point, 4326)[],
   mode TEXT,
   options text[] DEFAULT ARRAY[]::text[],


### PR DESCRIPTION
See #242
Dataservices functions are replaced by their new, exception-safe counterparts.

The functions have been replaced using this Ruby script:

```ruby
# Replace dataservices function calls by corresponding exception safe functions

DS_DIR = "~/www/dataservices-api/current"
functions_to_replace = `cat #{DS_DIR}/client/renderer/interface.yaml | grep -- '- name:' | awk '{print $3}'`.split
files_to_be_replaced = Dir['**/*.{js,sql}']

def exception_safe(f)
  "_#{f}_exception_safe"
end

files_to_be_replaced.each do |file|
  puts "Replacing in #{file}"  
  functions_to_replace.each do |fn|
    # It would be nice for this to be case insensitive, preserving case. But it isn't.
    # Note that the \b word boundaries makes this idempotent
    output = `sed -i -e "s/\\b#{fn}\\b/#{exception_safe(fn)}/g" "#{file}"`
    if !output.strip.empty?
      puts "  Replacing #{fn} :"
      puts output
    end
  end
end

# Problems: (must be solved manually)
# filenames replaced in test/setup.js (mock functions are defined in files named after the function)
```

The `test/setup.js` have been discarded.
