### PR TITLE
260 analyze after cache table creation

### DIFF
--- a/lib/service/database.js
+++ b/lib/service/database.js
@@ -249,6 +249,10 @@ function checkCacheTableQuery(targetTableName) {
     return 'SELECT CDB_CheckAnalysisQuota(\'' + targetTableName + '\')';
 }
 
+function analyzeTableQuery(targetTableName) {
+    return 'ANALYZE ' + targetTableName;
+}
+
 function updateNodeAtAnalysisCatalogQuery(nodeIds, columns) {
     nodeIds = Array.isArray(nodeIds) ? nodeIds : [nodeIds];
     return [
@@ -321,7 +325,8 @@ DatabaseService.prototype.queueAnalysisOperations = function(analysis, callback)
                     query: annotateNodeType(nodeToUpdate) + transactionQuery([
                         deleteFromCacheTableQuery(targetTableName),
                         populateCacheTableQuery(targetTableName, nodeToUpdate.sql()),
-                        checkCacheTableQuery(targetTableName)
+                        checkCacheTableQuery(targetTableName),
+                        analyzeTableQuery(targetTableName)
                     ]),
                     onsuccess: updateNodeAtAnalysisCatalogForJobResultQuery(nodeIds, Node.STATUS.READY),
                     onerror: updateNodeAtAnalysisCatalogForJobResultQuery(nodeIds, Node.STATUS.FAILED, true)


### PR DESCRIPTION
Pretty much described in the issue and in the commit messages but repeating here for convenience.

This PR ensures that ANALYZE is run along with the rest of the batch queries used for cache table creation in order to have up-to-date stats, instead of waiting for the autovacuum process to run it on the table.

The advantage of this is that stats are fresh as soon as the analysis is marked as ready, so that row count estimates can be used and the query planner can also benefit from it.