### PR TITLE
Fix DO Analysis failing in any table with an "id" column"

### DIFF
--- a/lib/node/nodes/data-observatory-measure.js
+++ b/lib/node/nodes/data-observatory-measure.js
@@ -39,7 +39,7 @@ var queryTemplate = Node.template([
     '          , null, null, numgeoms) as meta FROM _summary ',
     '  ), ',
     '_data AS ( ',
-    '  SELECT id, (data->0->>\'value\')::Numeric {{=it.final_column}} ',
+    '  SELECT id AS __obs_id__, (data->0->>\'value\')::Numeric {{=it.final_column}} ',
     '  FROM cdb_dataservices_client.OBS_GetData( ',
     '    (SELECT geomvals FROM _summary), ',
     '    (SELECT jsonb_set(meta::jsonb, \'{0,normalization}\', ',
@@ -52,5 +52,5 @@ var queryTemplate = Node.template([
     '  )) ',
     'SELECT {{=it.columns}}, _data.{{=it.final_column}} ',
     'FROM _data, ({{=it.source}}) AS _camshaft_do_measure_analysis ',
-    'WHERE _camshaft_do_measure_analysis.cartodb_id = _data.id '
+    'WHERE _camshaft_do_measure_analysis.cartodb_id = _data.__obs_id__ '
 ].join('\n'));

--- a/test/acceptance/data-observatory-measure.js
+++ b/test/acceptance/data-observatory-measure.js
@@ -5,6 +5,7 @@ var testHelper = require('../helper');
 
 describe('data-observatory-measure analysis', function() {
     var QUERY = 'select * from atm_machines limit 2';
+    var QUERY_WITH_ID = 'select *, cartodb_id AS id from atm_machines limit 2';
     var FINAL_COLUMN = 'adults_first_level_studies';
     var SEGMENT_NAME = 'es.ine.t15_8';
 
@@ -12,6 +13,13 @@ describe('data-observatory-measure analysis', function() {
         type: 'source',
         params: {
             query: QUERY
+        }
+    };
+
+    var sourceBarriosWithId = {
+        type: 'source',
+        params: {
+            query: QUERY_WITH_ID
         }
     };
 
@@ -40,6 +48,36 @@ describe('data-observatory-measure analysis', function() {
                     });
 
                     return done();
+                });
+            });
+        });
+
+        describe('data observatory measure analysis on table with column "id"', function () {
+            var doMeasureDefinition = {
+                type: 'data-observatory-measure',
+                params: {
+                    source: sourceBarriosWithId,
+                    final_column: FINAL_COLUMN,
+                    segment_name: SEGMENT_NAME,
+                    percent: false
+                }
+            };
+            it('should create an analysis', function (done) {
+                testHelper.createAnalyses(doMeasureDefinition, function(err, doMeasure) {
+                    assert.ifError(err);
+
+                    var rootNode = doMeasure.getRoot();
+
+                    testHelper.getRows(rootNode.getQuery(), function(err, rows) {
+                        assert.ifError(err);
+                        rows.forEach(function(row) {
+                            assert.ok(typeof row.cartodb_id === 'number');
+                            assert.ok(typeof row.id === 'number');
+                            assert.ok(typeof row.the_geom === 'string');
+                        });
+
+                        return done();
+                    });
                 });
             });
         });


### PR DESCRIPTION
Fixes #264.

Tables with a column called `__obs_id__` will fail instead, but it's impossible to prevent some kind of overlap unless `{{=it.columns}}` is changed to specify a source table.