### PR TITLE
Cache `filter-by-node-column` and `merge` nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Released 2017-mm-dd
 
+- Cache `filter-by-node-column` and `merge` nodes.
+
 ## 0.50.1
 
 Released 2017-02-21

--- a/lib/node/nodes/filter-by-node-column.js
+++ b/lib/node/nodes/filter-by-node-column.js
@@ -10,7 +10,7 @@ var PARAMS = {
     filter_column: Node.PARAM.STRING()
 };
 
-var FilterByColumn = Node.create(TYPE, PARAMS);
+var FilterByColumn = Node.create(TYPE, PARAMS, { cache: true, version: 1 });
 
 module.exports = FilterByColumn;
 

--- a/lib/node/nodes/merge.js
+++ b/lib/node/nodes/merge.js
@@ -19,7 +19,7 @@ var PARAMS = {
     right_source_columns: Node.PARAM.NULLABLE(Node.PARAM.ARRAY(Node.PARAM.STRING()), [])
 };
 
-var Merge = Node.create(TYPE, PARAMS);
+var Merge = Node.create(TYPE, PARAMS, { cache: true, version: 1 });
 
 module.exports = Merge;
 


### PR DESCRIPTION
For new analysis use the following checklist:

- [ ] Uses `the_geom geometry(Geometry, 4326)` column for all geospatial operations.
- [ ] Outputs a `the_geom geometry(Geometry, 4326)` column.
- [ ] Outputs a `cartodb_id numeric` column.
- [ ] Uses `{cache: true}` option when it needs full knowledge of the table it. Hints: aggregations, window functions.
- [ ] Uses `{cache: true}` if it access external services.
- [ ] Naming uses a-z lowercase and hyphens.
- [ ] All mandatory params cannot be made optional.
- [ ] Avoids using CTEs for join operations when result is not cached.
