### PR TITLE
Source node stores the affected tables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea/
+.vscode/
 node_modules/
 coverage/
 npm-debug.log

--- a/lib/node/node.js
+++ b/lib/node/node.js
@@ -294,14 +294,17 @@ Node.prototype.getAllInputNodes = function(filterFn) {
 
     function getAllInputNodes(node, nodeList) {
         node.getInputNodes().forEach(function(inputNode) {
-            nodeList.push(inputNode);
+            nodeList[inputNode.id()] = inputNode;
             getAllInputNodes(inputNode, nodeList);
         });
 
         return nodeList;
     }
 
-    return getAllInputNodes(this, []).filter(filterFn);
+    var inputNodes = getAllInputNodes(this, {});
+    return Object.keys(inputNodes).map(function(nodeId){
+        return inputNodes[nodeId];
+    }).filter(filterFn);
 };
 
 Node.prototype.shouldCacheQuery = function() {

--- a/lib/node/node.js
+++ b/lib/node/node.js
@@ -229,9 +229,6 @@ Node.prototype.getAffectedTables = function() {
 
 Node.prototype.addAffectedTables = function(affectedTables) {
     var tables = affectedTables;
-    if (!Array.isArray(tables))  {
-        tables = [affectedTables];
-    }
     this.affectedTables = this.affectedTables.concat(tables);
 };
 

--- a/lib/node/node.js
+++ b/lib/node/node.js
@@ -53,7 +53,8 @@ var NODE_RESERVED_KEYWORDS = {
     inputNodes: 1,
     attrs: 1,
     tags: 1,
-    setStatusFromInputNodes: 1
+    setStatusFromInputNodes: 1,
+    affectedTables: 1
 };
 
 function Node() {
@@ -82,6 +83,7 @@ function Node() {
     this.inputNodes = [];
 
     this.updatedAt = null;
+    this.affectedTables = [];
 
     this.attrs = {};
 
@@ -219,6 +221,18 @@ Node.prototype.getUpdatedAt = function() {
 
 Node.prototype.setUpdatedAt = function(updatedAt) {
     this.updatedAt = (updatedAt === null) ? null : new Date(updatedAt);
+};
+
+Node.prototype.getAffectedTables = function() {
+    return this.affectedTables;
+};
+
+Node.prototype.addAffectedTables = function(affectedTables) {
+    var tables = affectedTables;
+    if (!Array.isArray(tables))  {
+        tables = [affectedTables];
+    }
+    this.affectedTables = this.affectedTables.concat(tables);
 };
 
 Node.prototype.getLastUpdatedAtFromInputNodes = function() {

--- a/lib/node/node.js
+++ b/lib/node/node.js
@@ -291,21 +291,19 @@ Node.prototype.getInputNodes = function() {
 
 Node.prototype.getAllInputNodes = function(filterFn) {
     filterFn = filterFn || function() { return true; };
-
-    function getAllInputNodes(node, nodeList) {
-        node.getInputNodes().forEach(function(inputNode) {
-            nodeList[inputNode.id()] = inputNode;
-            getAllInputNodes(inputNode, nodeList);
-        });
-
-        return nodeList;
-    }
-
-    var inputNodes = getAllInputNodes(this, {});
+    var inputNodes = _getAllInputNodes(this, {});
     return Object.keys(inputNodes).map(function(nodeId){
         return inputNodes[nodeId];
     }).filter(filterFn);
 };
+
+function _getAllInputNodes(node, nodeList) {
+    node.getInputNodes().forEach(function(inputNode) {
+        nodeList[inputNode.id()] = inputNode;
+        _getAllInputNodes(inputNode, nodeList);
+    });
+    return nodeList;
+}
 
 Node.prototype.shouldCacheQuery = function() {
     return this.cacheQuery;

--- a/lib/node/node.js
+++ b/lib/node/node.js
@@ -292,6 +292,21 @@ Node.prototype.getInputNodes = function() {
     return this.inputNodes;
 };
 
+Node.prototype.getAllInputNodes = function(filterFn) {
+    filterFn = filterFn || function() { return true; };
+
+    function getAllInputNodes(node, nodeList) {
+        node.getInputNodes().forEach(function(inputNode) {
+            nodeList.push(inputNode);
+            getAllInputNodes(inputNode, nodeList);
+        });
+
+        return nodeList;
+    }
+
+    return getAllInputNodes(this, []).filter(filterFn);
+};
+
 Node.prototype.shouldCacheQuery = function() {
     return this.cacheQuery;
 };

--- a/lib/service/database.js
+++ b/lib/service/database.js
@@ -66,7 +66,7 @@ var affectedTableRegexCache = {
     pixelHeight: /!pixel_height!/g
 };
 
-DatabaseService.prototype.getLastUpdatedTimeFromAffectedTables = function(node, skip, callback) {
+DatabaseService.prototype.getLastUpdatedTimeAndTableDataFromAffectedTables = function(node, skip, callback) {
     if (!!skip || node.type !== Source.TYPE || node.getUpdatedAt() !== null) {
         var data = {'last_update': node.getUpdatedAt(),
                     'affected_tables': node.getAffectedTables()};

--- a/lib/service/database.js
+++ b/lib/service/database.js
@@ -66,7 +66,7 @@ var affectedTableRegexCache = {
     pixelHeight: /!pixel_height!/g
 };
 
-DatabaseService.prototype.getLastUpdatedTimeAndTableDataFromAffectedTables = function(node, skip, callback) {
+DatabaseService.prototype.getMetadataFromAffectedTables = function(node, skip, callback) {
     if (!!skip || node.type !== Source.TYPE || node.getUpdatedAt() !== null) {
         var data = {'last_update': node.getUpdatedAt(),
                     'affected_tables': node.getAffectedTables()};

--- a/lib/service/database.js
+++ b/lib/service/database.js
@@ -128,7 +128,7 @@ DatabaseService.prototype.tableExists = function(targetTableName, callback) {
 
 function composeTableName(schema, table) {
     if (schema !== null && table !== null) {
-        return schema + '.' + table;
+        return '"' + schema + '"."' + table + '"';
     }
     return null;
 }
@@ -275,6 +275,13 @@ function analyzeTableQuery(targetTableName) {
     return 'ANALYZE ' + targetTableName;
 }
 
+function invalidateCache(targetTableNames) {
+    var invalidations = targetTableNames.map(function(tableName) {
+       return 'cdb_invalidate_varnish(\'' + tableName + '\')';
+    });
+    return 'SELECT ' + invalidations;
+}
+
 function updateNodeAtAnalysisCatalogQuery(nodeIds, columns) {
     nodeIds = Array.isArray(nodeIds) ? nodeIds : [nodeIds];
     return [
@@ -322,6 +329,7 @@ DatabaseService.prototype.queueAnalysisOperations = function(analysis, callback)
         }
 
         var asyncQueries = [];
+        var affectedTables = {};
 
         // we want to mark all nodes updated_at to NOW() before doing any work on them
         nodesToQueueForUpdate.forEach(function(nodeToUpdate) {
@@ -334,6 +342,11 @@ DatabaseService.prototype.queueAnalysisOperations = function(analysis, callback)
         });
 
         nodesToQueueForUpdate.forEach(function(nodeToUpdate) {
+            getSourceNodes(nodeToUpdate).forEach(function(node) {
+                node.getAffectedTables().forEach(function(table){
+                    affectedTables[table] = ++affectedTables[table] || 1;
+                });
+            });
             if (nodeToUpdate.shouldCacheQuery()) {
                 nodeToUpdate.setQueuedWork(true);
                 var nodeIds = [nodeToUpdate.id(), nodeToUpdate.cachedNodeId()];
@@ -359,6 +372,10 @@ DatabaseService.prototype.queueAnalysisOperations = function(analysis, callback)
                     onerror: updateNodeStatusAtAnalysisCatalogQuery(nodeToUpdate.id(), Node.STATUS.FAILED)
                 });
             }
+        });
+
+        asyncQueries.push({
+            query: invalidateCache(Object.keys(affectedTables))
         });
 
         if (asyncQueries.length) {
@@ -437,6 +454,12 @@ function setCacheQueryTimeoutFromLimits(node, limits) {
             return false;
         }
         return true;
+    });
+}
+
+function getSourceNodes(node) {
+    return node.getAllInputNodes(function (node) {
+        return node.getType() === 'source';
     });
 }
 

--- a/lib/service/database.js
+++ b/lib/service/database.js
@@ -68,7 +68,7 @@ var affectedTableRegexCache = {
 
 DatabaseService.prototype.getLastUpdatedTimeFromAffectedTables = function(node, skip, callback) {
     if (!!skip || node.type !== Source.TYPE || node.getUpdatedAt() !== null) {
-        return callback(null, node.getUpdatedAt());
+        return callback(null, node.getUpdatedAt(), node.getAffectedTables());
     }
 
     var sql = node.sql()
@@ -76,7 +76,9 @@ DatabaseService.prototype.getLastUpdatedTimeFromAffectedTables = function(node, 
         .replace(affectedTableRegexCache.scaleDenominator, '0')
         .replace(affectedTableRegexCache.pixelWidth, '1')
         .replace(affectedTableRegexCache.pixelHeight, '1');
-    sql = 'SELECT max(updated_at) FROM CDB_QueryTables_Updated_At($camshaft$' + sql + '$camshaft$)';
+    sql = 'SELECT max(updated_at), schema_name, table_name ' +
+          'FROM CDB_QueryTables_Updated_At($camshaft$' + sql + '$camshaft$) ' +
+          'GROUP BY schema_name, table_name';
 
     this.queryRunner.run(sql, QUERY_RUNNER_READONLY_OP, function(err, resultSet) {
         if (err) {
@@ -84,10 +86,18 @@ DatabaseService.prototype.getLastUpdatedTimeFromAffectedTables = function(node, 
         }
 
         var defaultLastUpdatedTime = new Date('1970-01-01T00:00:00.000Z');
-        var rows = resultSet.rows || [defaultLastUpdatedTime];
-        var lastUpdatedTimeFromAffectedTables = (rows[0] && rows[0].max) || defaultLastUpdatedTime;
+        var affectedTables = [];
+        var lastUpdatedTimes = [];
+        var rows = resultSet.rows || [defaultLastUpdatedTime, null, null];
+        rows.forEach(function(row) {
+            lastUpdatedTimes.push((row && row.max) || defaultLastUpdatedTime);
+            var schema = (row && row.schema_name) || null;
+            var table = (row && row.table_name) || null;
+            affectedTables.push(composeTableName(schema, table));
+        });
+        var lastUpdatedTimeFromAffectedTables = new Date(Math.max.apply(null, lastUpdatedTimes));
 
-        return callback(null, lastUpdatedTimeFromAffectedTables);
+        return callback(null, lastUpdatedTimeFromAffectedTables, affectedTables);
     });
 };
 
@@ -110,6 +120,13 @@ DatabaseService.prototype.tableExists = function(targetTableName, callback) {
         return callback(null, tableExists);
     });
 };
+
+function composeTableName(schema, table) {
+    if (schema !== null && table !== null) {
+        return schema + '.' + table;
+    }
+    return null;
+}
 
 var DUPLICATED_TABLE_ERROR_CODES = {
     '42P07': true, // duplicate_table

--- a/lib/service/database.js
+++ b/lib/service/database.js
@@ -321,7 +321,6 @@ DatabaseService.prototype.queueAnalysisOperations = function(analysis, callback)
         }
 
         var asyncQueries = [];
-        var affectedTables = {};
 
         // we want to mark all nodes updated_at to NOW() before doing any work on them
         nodesToQueueForUpdate.forEach(function(nodeToUpdate) {
@@ -334,11 +333,6 @@ DatabaseService.prototype.queueAnalysisOperations = function(analysis, callback)
         });
 
         nodesToQueueForUpdate.forEach(function(nodeToUpdate) {
-            getSourceNodes(nodeToUpdate).forEach(function(node) {
-                node.getAffectedTables().forEach(function(table){
-                    affectedTables[table] = ++affectedTables[table] || 1;
-                });
-            });
             if (nodeToUpdate.shouldCacheQuery()) {
                 nodeToUpdate.setQueuedWork(true);
                 var nodeIds = [nodeToUpdate.id(), nodeToUpdate.cachedNodeId()];
@@ -358,16 +352,22 @@ DatabaseService.prototype.queueAnalysisOperations = function(analysis, callback)
                     onsuccess: updateNodeAtAnalysisCatalogForJobResultQuery(nodeIds, Node.STATUS.READY),
                     onerror: updateNodeAtAnalysisCatalogForJobResultQuery(nodeIds, Node.STATUS.FAILED, true)
                 });
+                var affectedTables = getSourceNodes(nodeToUpdate).reduce(function(list, node) {
+                    node.getAffectedTables().forEach(function(table){
+                        list[table] = ++list[table] || 1;
+                    });
+                    return list;
+                }, {});
+                asyncQueries.push({
+                    query: invalidateCache(Object.keys(affectedTables))
+                });
+
             } else {
                 asyncQueries.push({
                     query: updateNodeStatusAtAnalysisCatalogQuery(nodeToUpdate.id(), Node.STATUS.READY),
                     onerror: updateNodeStatusAtAnalysisCatalogQuery(nodeToUpdate.id(), Node.STATUS.FAILED)
                 });
             }
-        });
-
-        asyncQueries.push({
-            query: invalidateCache(Object.keys(affectedTables))
         });
 
         if (asyncQueries.length) {

--- a/lib/service/database.js
+++ b/lib/service/database.js
@@ -78,9 +78,8 @@ DatabaseService.prototype.getLastUpdatedTimeFromAffectedTables = function(node, 
         .replace(affectedTableRegexCache.scaleDenominator, '0')
         .replace(affectedTableRegexCache.pixelWidth, '1')
         .replace(affectedTableRegexCache.pixelHeight, '1');
-    sql = 'SELECT max(updated_at), schema_name, table_name ' +
-          'FROM CDB_QueryTables_Updated_At($camshaft$' + sql + '$camshaft$) ' +
-          'GROUP BY schema_name, table_name';
+    sql = 'SELECT updated_at, schema_name, table_name ' +
+          'FROM CDB_QueryTables_Updated_At($camshaft$' + sql + '$camshaft$)';
 
     this.queryRunner.run(sql, QUERY_RUNNER_READONLY_OP, function(err, resultSet) {
         if (err) {
@@ -92,7 +91,7 @@ DatabaseService.prototype.getLastUpdatedTimeFromAffectedTables = function(node, 
         var lastUpdatedTimes = [];
         var rows = resultSet.rows || [defaultLastUpdatedTime, null, null];
         rows.forEach(function(row) {
-            lastUpdatedTimes.push((row && row.max) || defaultLastUpdatedTime);
+            lastUpdatedTimes.push((row && row.updated_at) || defaultLastUpdatedTime);
             var schema = (row && row.schema_name) || null;
             var table = (row && row.table_name) || null;
             affectedTables.push(composeTableName(schema, table));

--- a/lib/service/database.js
+++ b/lib/service/database.js
@@ -128,7 +128,7 @@ DatabaseService.prototype.tableExists = function(targetTableName, callback) {
 
 function composeTableName(schema, table) {
     if (schema !== null && table !== null) {
-        return '"' + schema + '"."' + table + '"';
+        return schema + '.' + table;
     }
     return null;
 }

--- a/lib/service/database.js
+++ b/lib/service/database.js
@@ -94,7 +94,7 @@ DatabaseService.prototype.getLastUpdatedTimeFromAffectedTables = function(node, 
             lastUpdatedTimes.push((row && row.updated_at) || defaultLastUpdatedTime);
             var schema = (row && row.schema_name) || null;
             var table = (row && row.table_name) || null;
-            affectedTables.push(composeTableName(schema, table));
+            affectedTables.push({'schema': schema, 'table': table});
         });
         var lastUpdatedTimeFromAffectedTables = new Date(Math.max.apply(null, lastUpdatedTimes));
         var data = {'last_update': lastUpdatedTimeFromAffectedTables,
@@ -124,13 +124,6 @@ DatabaseService.prototype.tableExists = function(targetTableName, callback) {
         return callback(null, tableExists);
     });
 };
-
-function composeTableName(schema, table) {
-    if (schema !== null && table !== null) {
-        return schema + '.' + table;
-    }
-    return null;
-}
 
 var DUPLICATED_TABLE_ERROR_CODES = {
     '42P07': true, // duplicate_table

--- a/lib/service/database.js
+++ b/lib/service/database.js
@@ -68,7 +68,9 @@ var affectedTableRegexCache = {
 
 DatabaseService.prototype.getLastUpdatedTimeFromAffectedTables = function(node, skip, callback) {
     if (!!skip || node.type !== Source.TYPE || node.getUpdatedAt() !== null) {
-        return callback(null, node.getUpdatedAt(), node.getAffectedTables());
+        var data = {'last_update': node.getUpdatedAt(),
+                    'affected_tables': node.getAffectedTables()};
+        return callback(null, data);
     }
 
     var sql = node.sql()
@@ -96,8 +98,11 @@ DatabaseService.prototype.getLastUpdatedTimeFromAffectedTables = function(node, 
             affectedTables.push(composeTableName(schema, table));
         });
         var lastUpdatedTimeFromAffectedTables = new Date(Math.max.apply(null, lastUpdatedTimes));
+        var data = {'last_update': lastUpdatedTimeFromAffectedTables,
+                    'affected_tables': affectedTables};
 
-        return callback(null, lastUpdatedTimeFromAffectedTables, affectedTables);
+
+        return callback(null, data);
     });
 };
 

--- a/lib/workflow/factory.js
+++ b/lib/workflow/factory.js
@@ -87,7 +87,7 @@ Factory.prototype._create = function (definition, depth, callback) {
         }
 
         var skipUpdate = depth === 1;
-        self.databaseService.getLastUpdatedTimeAndTableDataFromAffectedTables(node, skipUpdate,
+        self.databaseService.getMetadataFromAffectedTables(node, skipUpdate,
         function(err, data) {
             if (err) {
                 return callback(err);

--- a/lib/workflow/factory.js
+++ b/lib/workflow/factory.js
@@ -89,7 +89,6 @@ Factory.prototype._create = function (definition, depth, callback) {
         var skipUpdate = depth === 1;
         self.databaseService.getLastUpdatedTimeFromAffectedTables(node, skipUpdate, 
         function(err, data) {
-            debug('dataloco ', data);
             if (err) {
                 return callback(err);
             }

--- a/lib/workflow/factory.js
+++ b/lib/workflow/factory.js
@@ -88,12 +88,13 @@ Factory.prototype._create = function (definition, depth, callback) {
 
         var skipUpdate = depth === 1;
         self.databaseService.getLastUpdatedTimeFromAffectedTables(node, skipUpdate, 
-        function(err, lastUpdatedAt, affectedTables) {
+        function(err, data) {
+            debug('dataloco ', data);
             if (err) {
                 return callback(err);
             }
-            node.setUpdatedAt(lastUpdatedAt);
-            node.addAffectedTables(affectedTables);
+            node.setUpdatedAt(data.last_update);
+            node.addAffectedTables(data.affected_tables);
 
             self.databaseService.getColumns(node.sql(), function(err, columns) {
                 if (err) {

--- a/lib/workflow/factory.js
+++ b/lib/workflow/factory.js
@@ -87,7 +87,7 @@ Factory.prototype._create = function (definition, depth, callback) {
         }
 
         var skipUpdate = depth === 1;
-        self.databaseService.getLastUpdatedTimeFromAffectedTables(node, skipUpdate, 
+        self.databaseService.getLastUpdatedTimeAndTableDataFromAffectedTables(node, skipUpdate,
         function(err, data) {
             if (err) {
                 return callback(err);

--- a/lib/workflow/factory.js
+++ b/lib/workflow/factory.js
@@ -93,7 +93,6 @@ Factory.prototype._create = function (definition, depth, callback) {
                 return callback(err);
             }
             node.setUpdatedAt(lastUpdatedAt);
-            debug('affected tables', affectedTables);
             node.addAffectedTables(affectedTables);
 
             self.databaseService.getColumns(node.sql(), function(err, columns) {

--- a/lib/workflow/factory.js
+++ b/lib/workflow/factory.js
@@ -93,7 +93,10 @@ Factory.prototype._create = function (definition, depth, callback) {
                 return callback(err);
             }
             node.setUpdatedAt(data.last_update);
-            node.addAffectedTables(data.affected_tables);
+            var affectedTables = data.affected_tables.map(function(table){
+                return table.schema + '.' + table.table;
+            });
+            node.addAffectedTables(affectedTables);
 
             self.databaseService.getColumns(node.sql(), function(err, columns) {
                 if (err) {

--- a/lib/workflow/factory.js
+++ b/lib/workflow/factory.js
@@ -87,11 +87,14 @@ Factory.prototype._create = function (definition, depth, callback) {
         }
 
         var skipUpdate = depth === 1;
-        self.databaseService.getLastUpdatedTimeFromAffectedTables(node, skipUpdate, function(err, lastUpdatedAt) {
+        self.databaseService.getLastUpdatedTimeFromAffectedTables(node, skipUpdate, 
+        function(err, lastUpdatedAt, affectedTables) {
             if (err) {
                 return callback(err);
             }
             node.setUpdatedAt(lastUpdatedAt);
+            debug('affected tables', affectedTables);
+            node.addAffectedTables(affectedTables);
 
             self.databaseService.getColumns(node.sql(), function(err, columns) {
                 if (err) {

--- a/test/fixtures/cdb_invalidate_varnish.sql
+++ b/test/fixtures/cdb_invalidate_varnish.sql
@@ -1,0 +1,6 @@
+CREATE OR REPLACE FUNCTION CDB_Invalidate_Varnish(table_name TEXT)
+RETURNS void AS
+$$
+BEGIN
+END;
+$$ LANGUAGE PLPGSQL;

--- a/test/fixtures/cdb_querytables_updated_at.sql
+++ b/test/fixtures/cdb_querytables_updated_at.sql
@@ -4,7 +4,10 @@ AS $$
     SELECT
     'analysis_api_test_db'::text,
     'public'::text,
-    'table_name'::text,
+    CASE WHEN position('atm_machines' in query) > 0 THEN 'atm_machines'::text
+         WHEN position('multiple_tables' in query) > 0 THEN unnest(ARRAY['table_a', 'table_b']::text[])
+         ELSE 'fixture_table_name'::text
+    END,
     CASE WHEN position('nulltime' in query) > 0
         THEN null::timestamptz
         ELSE '2016-07-01 11:40:05.699712+00'::timestamptz

--- a/test/integration/analysis.js
+++ b/test/integration/analysis.js
@@ -107,7 +107,7 @@ describe('workflow', function() {
                 return callback(null, {status: 'ok'});
             };
 
-            Analysis.create(testConfig, tradeAreaAnalysisDefinition, function(err, analysis) {
+            Analysis.create(testConfig, tradeAreaAnalysisDefinition, function(err) {
                 BatchClient.prototype.enqueue = enqueueFn;
 
                 assert.ok(enqueueCalled);

--- a/test/integration/analysis.js
+++ b/test/integration/analysis.js
@@ -113,7 +113,7 @@ describe('workflow', function() {
                 assert.ok(enqueueCalled);
                 assert.ok(!err, err);
                 assert.ok(invalidateQuery.match(
-                    new RegExp('select cdb_invalidate_varnish\\(\'"public"."atm_machines"\'\\)', 'i')
+                    new RegExp('select cdb_invalidate_varnish\\(\'public.atm_machines\'\\)', 'i')
                 ));
 
                 done();

--- a/test/integration/database-service.js
+++ b/test/integration/database-service.js
@@ -21,18 +21,18 @@ describe('database-service', function() {
 
     it('should return time from CDB_QueryTables_Updated_At', function(done) {
         var source = new Source(testConfig.user, { query: QUERY_QUERYTABLES });
-        this.databaseService.getLastUpdatedTimeFromAffectedTables(source, !SKIP, function(err, lastUpdatedTime) {
+        this.databaseService.getLastUpdatedTimeFromAffectedTables(source, !SKIP, function(err, data) {
             assert.ok(!err, err);
-            assert.equal(lastUpdatedTime.getTime(), new Date('2016-07-01T11:40:05.699Z').getTime());
+            assert.equal(data.last_update.getTime(), new Date('2016-07-01T11:40:05.699Z').getTime());
             done();
         });
     });
 
     it('should return a fixed time in the past for tables not found by CDB_QueryTables_Updated_At', function(done) {
         var source = new Source(testConfig.user, { query: QUERY_NO_QUERYTABLES });
-        this.databaseService.getLastUpdatedTimeFromAffectedTables(source, !SKIP, function(err, lastUpdatedTime) {
+        this.databaseService.getLastUpdatedTimeFromAffectedTables(source, !SKIP, function(err, data) {
             assert.ok(!err, err);
-            assert.equal(lastUpdatedTime.getTime(), new Date('1970-01-01T00:00:00.000Z').getTime());
+            assert.equal(data.last_update.getTime(), new Date('1970-01-01T00:00:00.000Z').getTime());
             done();
         });
     });
@@ -61,9 +61,9 @@ describe('database-service', function() {
     it('should return affected table names for source nodes', function(done) {
         var source = new Source(testConfig.user, { query: QUERY_QUERYTABLES });
         this.databaseService.getLastUpdatedTimeFromAffectedTables(source, !SKIP,
-        function(err, lastUpdatedTime, tables) {
+        function(err, data) {
             assert.ok(!err, err);
-            tables.forEach(function(tableName) {
+            data.affected_tables.forEach(function(tableName) {
                 assert.equal(tableName, 'public.atm_machines');
             });
             done();
@@ -73,12 +73,12 @@ describe('database-service', function() {
     it('should return two affected table names for source node', function(done) {
         var source = new Source(testConfig.user, { query: QUERY_MULTIPLETABLES });
         this.databaseService.getLastUpdatedTimeFromAffectedTables(source, !SKIP,
-        function(err, lastUpdatedTime, tables) {
+        function(err, data) {
             assert.ok(!err, err);
-            assert.equal(tables.length, 2);
-            assert.equal(tables[0], 'public.table_a');
-            assert.equal(tables[1], 'public.table_b');
-            assert.equal(lastUpdatedTime.getTime(), new Date('2016-07-01T11:40:05.699Z').getTime());
+            assert.equal(data.affected_tables.length, 2);
+            assert.equal(data.affected_tables[0], 'public.table_a');
+            assert.equal(data.affected_tables[1], 'public.table_b');
+            assert.equal(data.last_update.getTime(), new Date('2016-07-01T11:40:05.699Z').getTime());
             done();
         });
     });
@@ -87,9 +87,9 @@ describe('database-service', function() {
         var source = new Source(testConfig.user, { query: QUERY_QUERYTABLES });
         var buffer = new Buffer(testConfig.user, {source: source, radius: 100, isolines: 1, dissolved: false});
         this.databaseService.getLastUpdatedTimeFromAffectedTables(buffer, !SKIP,
-        function(err, lastUpdatedTime, tables) {
+        function(err, data) {
             assert.ok(!err, err);
-            assert.equal(tables.length, 0);
+            assert.equal(data.affected_tables.length, 0);
             done();
         });
     });

--- a/test/integration/database-service.js
+++ b/test/integration/database-service.js
@@ -64,7 +64,7 @@ describe('database-service', function() {
         function(err, data) {
             assert.ok(!err, err);
             data.affected_tables.forEach(function(tableName) {
-                assert.equal(tableName, 'public.atm_machines');
+                assert.equal(tableName, '"public"."atm_machines"');
             });
             done();
         });
@@ -76,8 +76,8 @@ describe('database-service', function() {
         function(err, data) {
             assert.ok(!err, err);
             assert.equal(data.affected_tables.length, 2);
-            assert.equal(data.affected_tables[0], 'public.table_a');
-            assert.equal(data.affected_tables[1], 'public.table_b');
+            assert.equal(data.affected_tables[0], '"public"."table_a"');
+            assert.equal(data.affected_tables[1], '"public"."table_b"');
             assert.equal(data.last_update.getTime(), new Date('2016-07-01T11:40:05.699Z').getTime());
             done();
         });

--- a/test/integration/database-service.js
+++ b/test/integration/database-service.js
@@ -3,14 +3,16 @@
 var assert = require('assert');
 
 var Source = require('../../lib/node/nodes/source');
+var Buffer = require('../../lib/node/nodes/buffer');
 
 var DatabaseService = require('../../lib/service/database');
 var testConfig = require('../test-config');
 
-describe('database-servie', function() {
+describe('database-service', function() {
 
     var SKIP = true;
     var QUERY_QUERYTABLES = 'select * from atm_machines';
+    var QUERY_MULTIPLETABLES = 'select * from multiple_tables';
     var QUERY_NO_QUERYTABLES = 'select * from nulltime';
 
     before(function() {
@@ -53,7 +55,43 @@ describe('database-servie', function() {
             assert.ok(!err, err);
 
             done();
-        }); 
+        });
+    });
+
+    it('should return affected table names for source nodes', function(done) {
+        var source = new Source(testConfig.user, { query: QUERY_QUERYTABLES });
+        this.databaseService.getLastUpdatedTimeFromAffectedTables(source, !SKIP,
+        function(err, lastUpdatedTime, tables) {
+            assert.ok(!err, err);
+            tables.forEach(function(tableName) {
+                assert.equal(tableName, 'public.atm_machines');
+            });
+            done();
+        });
+    });
+
+    it('should return two affected table names for source node', function(done) {
+        var source = new Source(testConfig.user, { query: QUERY_MULTIPLETABLES });
+        this.databaseService.getLastUpdatedTimeFromAffectedTables(source, !SKIP,
+        function(err, lastUpdatedTime, tables) {
+            assert.ok(!err, err);
+            assert.equal(tables.length, 2);
+            assert.equal(tables[0], 'public.table_a');
+            assert.equal(tables[1], 'public.table_b');
+            assert.equal(lastUpdatedTime.getTime(), new Date('2016-07-01T11:40:05.699Z').getTime());
+            done();
+        });
+    });
+
+    it('should return empty affected tables for non-source queries', function(done) {
+        var source = new Source(testConfig.user, { query: QUERY_QUERYTABLES });
+        var buffer = new Buffer(testConfig.user, {source: source, radius: 100, isolines: 1, dissolved: false});
+        this.databaseService.getLastUpdatedTimeFromAffectedTables(buffer, !SKIP,
+        function(err, lastUpdatedTime, tables) {
+            assert.ok(!err, err);
+            assert.equal(tables.length, 0);
+            done();
+        });
     });
 
 });

--- a/test/integration/database-service.js
+++ b/test/integration/database-service.js
@@ -21,7 +21,7 @@ describe('database-service', function() {
 
     it('should return time from CDB_QueryTables_Updated_At', function(done) {
         var source = new Source(testConfig.user, { query: QUERY_QUERYTABLES });
-        this.databaseService.getLastUpdatedTimeAndTableDataFromAffectedTables(source, !SKIP, function(err, data) {
+        this.databaseService.getMetadataFromAffectedTables(source, !SKIP, function(err, data) {
             assert.ok(!err, err);
             assert.equal(data.last_update.getTime(), new Date('2016-07-01T11:40:05.699Z').getTime());
             done();
@@ -30,7 +30,7 @@ describe('database-service', function() {
 
     it('should return a fixed time in the past for tables not found by CDB_QueryTables_Updated_At', function(done) {
         var source = new Source(testConfig.user, { query: QUERY_NO_QUERYTABLES });
-        this.databaseService.getLastUpdatedTimeAndTableDataFromAffectedTables(source, !SKIP, function(err, data) {
+        this.databaseService.getMetadataFromAffectedTables(source, !SKIP, function(err, data) {
             assert.ok(!err, err);
             assert.equal(data.last_update.getTime(), new Date('1970-01-01T00:00:00.000Z').getTime());
             done();
@@ -60,7 +60,7 @@ describe('database-service', function() {
 
     it('should return affected table names for source nodes', function(done) {
         var source = new Source(testConfig.user, { query: QUERY_QUERYTABLES });
-        this.databaseService.getLastUpdatedTimeAndTableDataFromAffectedTables(source, !SKIP,
+        this.databaseService.getMetadataFromAffectedTables(source, !SKIP,
         function(err, data) {
             assert.ok(!err, err);
             data.affected_tables.forEach(function(data) {
@@ -73,7 +73,7 @@ describe('database-service', function() {
 
     it('should return two affected table names for source node', function(done) {
         var source = new Source(testConfig.user, { query: QUERY_MULTIPLETABLES });
-        this.databaseService.getLastUpdatedTimeAndTableDataFromAffectedTables(source, !SKIP,
+        this.databaseService.getMetadataFromAffectedTables(source, !SKIP,
         function(err, data) {
             assert.ok(!err, err);
             assert.equal(data.affected_tables.length, 2);
@@ -89,7 +89,7 @@ describe('database-service', function() {
     it('should return empty affected tables for non-source queries', function(done) {
         var source = new Source(testConfig.user, { query: QUERY_QUERYTABLES });
         var buffer = new Buffer(testConfig.user, {source: source, radius: 100, isolines: 1, dissolved: false});
-        this.databaseService.getLastUpdatedTimeAndTableDataFromAffectedTables(buffer, !SKIP,
+        this.databaseService.getMetadataFromAffectedTables(buffer, !SKIP,
         function(err, data) {
             assert.ok(!err, err);
             assert.equal(data.affected_tables.length, 0);

--- a/test/integration/database-service.js
+++ b/test/integration/database-service.js
@@ -63,8 +63,9 @@ describe('database-service', function() {
         this.databaseService.getLastUpdatedTimeFromAffectedTables(source, !SKIP,
         function(err, data) {
             assert.ok(!err, err);
-            data.affected_tables.forEach(function(tableName) {
-                assert.equal(tableName, 'public.atm_machines');
+            data.affected_tables.forEach(function(data) {
+                assert.equal(data.schema, 'public');
+                assert.equal(data.table, 'atm_machines');
             });
             done();
         });
@@ -76,8 +77,10 @@ describe('database-service', function() {
         function(err, data) {
             assert.ok(!err, err);
             assert.equal(data.affected_tables.length, 2);
-            assert.equal(data.affected_tables[0], 'public.table_a');
-            assert.equal(data.affected_tables[1], 'public.table_b');
+            assert.equal(data.affected_tables[0].schema, 'public');
+            assert.equal(data.affected_tables[0].table, 'table_a');
+            assert.equal(data.affected_tables[1].schema, 'public');
+            assert.equal(data.affected_tables[1].table, 'table_b');
             assert.equal(data.last_update.getTime(), new Date('2016-07-01T11:40:05.699Z').getTime());
             done();
         });

--- a/test/integration/database-service.js
+++ b/test/integration/database-service.js
@@ -64,7 +64,7 @@ describe('database-service', function() {
         function(err, data) {
             assert.ok(!err, err);
             data.affected_tables.forEach(function(tableName) {
-                assert.equal(tableName, '"public"."atm_machines"');
+                assert.equal(tableName, 'public.atm_machines');
             });
             done();
         });
@@ -76,8 +76,8 @@ describe('database-service', function() {
         function(err, data) {
             assert.ok(!err, err);
             assert.equal(data.affected_tables.length, 2);
-            assert.equal(data.affected_tables[0], '"public"."table_a"');
-            assert.equal(data.affected_tables[1], '"public"."table_b"');
+            assert.equal(data.affected_tables[0], 'public.table_a');
+            assert.equal(data.affected_tables[1], 'public.table_b');
             assert.equal(data.last_update.getTime(), new Date('2016-07-01T11:40:05.699Z').getTime());
             done();
         });

--- a/test/integration/database-service.js
+++ b/test/integration/database-service.js
@@ -21,7 +21,7 @@ describe('database-service', function() {
 
     it('should return time from CDB_QueryTables_Updated_At', function(done) {
         var source = new Source(testConfig.user, { query: QUERY_QUERYTABLES });
-        this.databaseService.getLastUpdatedTimeFromAffectedTables(source, !SKIP, function(err, data) {
+        this.databaseService.getLastUpdatedTimeAndTableDataFromAffectedTables(source, !SKIP, function(err, data) {
             assert.ok(!err, err);
             assert.equal(data.last_update.getTime(), new Date('2016-07-01T11:40:05.699Z').getTime());
             done();
@@ -30,7 +30,7 @@ describe('database-service', function() {
 
     it('should return a fixed time in the past for tables not found by CDB_QueryTables_Updated_At', function(done) {
         var source = new Source(testConfig.user, { query: QUERY_NO_QUERYTABLES });
-        this.databaseService.getLastUpdatedTimeFromAffectedTables(source, !SKIP, function(err, data) {
+        this.databaseService.getLastUpdatedTimeAndTableDataFromAffectedTables(source, !SKIP, function(err, data) {
             assert.ok(!err, err);
             assert.equal(data.last_update.getTime(), new Date('1970-01-01T00:00:00.000Z').getTime());
             done();
@@ -60,7 +60,7 @@ describe('database-service', function() {
 
     it('should return affected table names for source nodes', function(done) {
         var source = new Source(testConfig.user, { query: QUERY_QUERYTABLES });
-        this.databaseService.getLastUpdatedTimeFromAffectedTables(source, !SKIP,
+        this.databaseService.getLastUpdatedTimeAndTableDataFromAffectedTables(source, !SKIP,
         function(err, data) {
             assert.ok(!err, err);
             data.affected_tables.forEach(function(data) {
@@ -73,7 +73,7 @@ describe('database-service', function() {
 
     it('should return two affected table names for source node', function(done) {
         var source = new Source(testConfig.user, { query: QUERY_MULTIPLETABLES });
-        this.databaseService.getLastUpdatedTimeFromAffectedTables(source, !SKIP,
+        this.databaseService.getLastUpdatedTimeAndTableDataFromAffectedTables(source, !SKIP,
         function(err, data) {
             assert.ok(!err, err);
             assert.equal(data.affected_tables.length, 2);
@@ -89,7 +89,7 @@ describe('database-service', function() {
     it('should return empty affected tables for non-source queries', function(done) {
         var source = new Source(testConfig.user, { query: QUERY_QUERYTABLES });
         var buffer = new Buffer(testConfig.user, {source: source, radius: 100, isolines: 1, dissolved: false});
-        this.databaseService.getLastUpdatedTimeFromAffectedTables(buffer, !SKIP,
+        this.databaseService.getLastUpdatedTimeAndTableDataFromAffectedTables(buffer, !SKIP,
         function(err, data) {
             assert.ok(!err, err);
             assert.equal(data.affected_tables.length, 0);

--- a/test/integration/nodes.js
+++ b/test/integration/nodes.js
@@ -190,8 +190,10 @@ describe('nodes', function() {
 
         it('should store the affected tables for the source node', function(done) {
             DatabaseService.prototype.getLastUpdatedTimeFromAffectedTables = function(node, skip, callback) {
-                return callback(null, {'last_update': new Date('2016-07-01'), 
-                                       'affected_tables': ['public.atm_machines']});
+                return callback(null, {'last_update': new Date('2016-07-01'),
+                                       'affected_tables': [
+                                           {'schema': 'public', 'table':'atm_machines'}
+                                        ]});
             };
             async.map([SOURCE_ATM_MACHINES_DEF], create, function(err, results) {
                 assert.ok(!err, err);
@@ -204,7 +206,7 @@ describe('nodes', function() {
 
         it('should store the affected tables for the non-source node', function(done) {
             DatabaseService.prototype.getLastUpdatedTimeFromAffectedTables = function(node, skip, callback) {
-                return callback(null, {'last_update': new Date('2016-07-01'), 
+                return callback(null, {'last_update': new Date('2016-07-01'),
                                        'affected_tables': []});
             };
             async.map([BUFFER_OVER_SOURCE], create, function(err, results) {

--- a/test/integration/nodes.js
+++ b/test/integration/nodes.js
@@ -127,7 +127,7 @@ describe('nodes', function() {
             var called = false;
             DatabaseService.prototype.getLastUpdatedTimeFromAffectedTables = function(node, skip, callback) {
                 if (node.type !== 'source' || node.getUpdatedAt() !== null) {
-                    return callback(null, node.getUpdatedAt());
+                    return callback(null, {'last_update': node.getUpdatedAt(), 'affected_tables': []});
                 }
                 var lastUpdatedTimeFromAffectedTables = new Date('2016-07-01');
                 if (called) {
@@ -136,7 +136,7 @@ describe('nodes', function() {
                 if (!called) {
                     called = true;
                 }
-                return callback(null, lastUpdatedTimeFromAffectedTables);
+                return callback(null, {'last_update': lastUpdatedTimeFromAffectedTables, 'affected_tables': []});
             };
 
             async.map([BUFFER_OVER_SOURCE, BUFFER_OVER_SOURCE], create, function(err, results) {
@@ -163,7 +163,7 @@ describe('nodes', function() {
 
         it('should have same ids for same query and same CDB_QueryTables_Updated_At result', function(done) {
             DatabaseService.prototype.getLastUpdatedTimeFromAffectedTables = function(node, skip, callback) {
-                return callback(null, new Date('2016-07-01'));
+                return callback(null, {'last_update': new Date('2016-07-01'), 'affected_tables': []});
             };
 
             async.map([BUFFER_OVER_SOURCE, BUFFER_OVER_SOURCE], create, function(err, results) {
@@ -190,7 +190,8 @@ describe('nodes', function() {
 
         it('should store the affected tables for the source node', function(done) {
             DatabaseService.prototype.getLastUpdatedTimeFromAffectedTables = function(node, skip, callback) {
-                return callback(null, new Date('2016-07-01'), ['public.atm_machines']);
+                return callback(null, {'last_update': new Date('2016-07-01'), 
+                                       'affected_tables': ['public.atm_machines']});
             };
             async.map([SOURCE_ATM_MACHINES_DEF], create, function(err, results) {
                 assert.ok(!err, err);
@@ -203,7 +204,8 @@ describe('nodes', function() {
 
         it('should store the affected tables for the non-source node', function(done) {
             DatabaseService.prototype.getLastUpdatedTimeFromAffectedTables = function(node, skip, callback) {
-                return callback(null, new Date('2016-07-01'), []);
+                return callback(null, {'last_update': new Date('2016-07-01'), 
+                                       'affected_tables': []});
             };
             async.map([BUFFER_OVER_SOURCE], create, function(err, results) {
                 assert.ok(!err, err);

--- a/test/integration/nodes.js
+++ b/test/integration/nodes.js
@@ -116,18 +116,18 @@ describe('nodes', function() {
                 return callback(null, {status: 'ok'});
             };
             getLastUpdatedTimeFromAffectedTablesFn =
-                DatabaseService.prototype.getLastUpdatedTimeAndTableDataFromAffectedTables;
+                DatabaseService.prototype.getMetadataFromAffectedTables;
         });
         afterEach(function() {
             assert.ok(enqueueCalled > 0);
             BatchClient.prototype.enqueue = enqueueFn;
-            DatabaseService.prototype.getLastUpdatedTimeAndTableDataFromAffectedTables =
+            DatabaseService.prototype.getMetadataFromAffectedTables =
                 getLastUpdatedTimeFromAffectedTablesFn;
         });
 
         it('should have different ids for same query but different CDB_QueryTables_Updated_At result', function(done) {
             var called = false;
-            DatabaseService.prototype.getLastUpdatedTimeAndTableDataFromAffectedTables = function(node, skip,
+            DatabaseService.prototype.getMetadataFromAffectedTables = function(node, skip,
             callback) {
                 if (node.type !== 'source' || node.getUpdatedAt() !== null) {
                     return callback(null, {'last_update': node.getUpdatedAt(), 'affected_tables': []});
@@ -165,7 +165,7 @@ describe('nodes', function() {
         });
 
         it('should have same ids for same query and same CDB_QueryTables_Updated_At result', function(done) {
-            DatabaseService.prototype.getLastUpdatedTimeAndTableDataFromAffectedTables = function(node, skip,
+            DatabaseService.prototype.getMetadataFromAffectedTables = function(node, skip,
                 callback) {
                 return callback(null, {'last_update': new Date('2016-07-01'), 'affected_tables': []});
             };
@@ -193,7 +193,7 @@ describe('nodes', function() {
         });
 
         it('should store the affected tables for the source node', function(done) {
-            DatabaseService.prototype.getLastUpdatedTimeAndTableDataFromAffectedTables = function(node, skip,
+            DatabaseService.prototype.getMetadataFromAffectedTables = function(node, skip,
                 callback) {
                 return callback(null, {'last_update': new Date('2016-07-01'),
                                        'affected_tables': [
@@ -210,7 +210,7 @@ describe('nodes', function() {
         });
 
         it('should store the affected tables for the non-source node', function(done) {
-            DatabaseService.prototype.getLastUpdatedTimeAndTableDataFromAffectedTables = function(node, skip,
+            DatabaseService.prototype.getMetadataFromAffectedTables = function(node, skip,
                 callback) {
                 return callback(null, {'last_update': new Date('2016-07-01'),
                                        'affected_tables': []});

--- a/test/integration/nodes.js
+++ b/test/integration/nodes.js
@@ -188,6 +188,32 @@ describe('nodes', function() {
             });
         });
 
+        it('should store the affected tables for the source node', function(done) {
+            DatabaseService.prototype.getLastUpdatedTimeFromAffectedTables = function(node, skip, callback) {
+                return callback(null, new Date('2016-07-01'), ['public.atm_machines']);
+            };
+            async.map([SOURCE_ATM_MACHINES_DEF], create, function(err, results) {
+                assert.ok(!err, err);
+                assert.equal(results.length, 1);
+                var sourceNode = results[0].rootNode;
+                assert.equal(sourceNode.getAffectedTables()[0], 'public.atm_machines');
+                done();
+            });
+        });
+
+        it('should store the affected tables for the non-source node', function(done) {
+            DatabaseService.prototype.getLastUpdatedTimeFromAffectedTables = function(node, skip, callback) {
+                return callback(null, new Date('2016-07-01'), []);
+            };
+            async.map([BUFFER_OVER_SOURCE], create, function(err, results) {
+                assert.ok(!err, err);
+                assert.equal(results.length, 1);
+                var sourceNode = results[0].rootNode;
+                assert.equal(sourceNode.getAffectedTables().length, 0);
+                done();
+            });
+        });
+
     });
 
     describe('operation', function() {

--- a/test/integration/nodes.js
+++ b/test/integration/nodes.js
@@ -115,17 +115,20 @@ describe('nodes', function() {
                 enqueueCalled += 1;
                 return callback(null, {status: 'ok'});
             };
-            getLastUpdatedTimeFromAffectedTablesFn = DatabaseService.prototype.getLastUpdatedTimeFromAffectedTables;
+            getLastUpdatedTimeFromAffectedTablesFn =
+                DatabaseService.prototype.getLastUpdatedTimeAndTableDataFromAffectedTables;
         });
         afterEach(function() {
             assert.ok(enqueueCalled > 0);
             BatchClient.prototype.enqueue = enqueueFn;
-            DatabaseService.prototype.getLastUpdatedTimeFromAffectedTables = getLastUpdatedTimeFromAffectedTablesFn;
+            DatabaseService.prototype.getLastUpdatedTimeAndTableDataFromAffectedTables =
+                getLastUpdatedTimeFromAffectedTablesFn;
         });
 
         it('should have different ids for same query but different CDB_QueryTables_Updated_At result', function(done) {
             var called = false;
-            DatabaseService.prototype.getLastUpdatedTimeFromAffectedTables = function(node, skip, callback) {
+            DatabaseService.prototype.getLastUpdatedTimeAndTableDataFromAffectedTables = function(node, skip,
+            callback) {
                 if (node.type !== 'source' || node.getUpdatedAt() !== null) {
                     return callback(null, {'last_update': node.getUpdatedAt(), 'affected_tables': []});
                 }
@@ -162,7 +165,8 @@ describe('nodes', function() {
         });
 
         it('should have same ids for same query and same CDB_QueryTables_Updated_At result', function(done) {
-            DatabaseService.prototype.getLastUpdatedTimeFromAffectedTables = function(node, skip, callback) {
+            DatabaseService.prototype.getLastUpdatedTimeAndTableDataFromAffectedTables = function(node, skip,
+                callback) {
                 return callback(null, {'last_update': new Date('2016-07-01'), 'affected_tables': []});
             };
 
@@ -189,7 +193,8 @@ describe('nodes', function() {
         });
 
         it('should store the affected tables for the source node', function(done) {
-            DatabaseService.prototype.getLastUpdatedTimeFromAffectedTables = function(node, skip, callback) {
+            DatabaseService.prototype.getLastUpdatedTimeAndTableDataFromAffectedTables = function(node, skip,
+                callback) {
                 return callback(null, {'last_update': new Date('2016-07-01'),
                                        'affected_tables': [
                                            {'schema': 'public', 'table':'atm_machines'}
@@ -205,7 +210,8 @@ describe('nodes', function() {
         });
 
         it('should store the affected tables for the non-source node', function(done) {
-            DatabaseService.prototype.getLastUpdatedTimeFromAffectedTables = function(node, skip, callback) {
+            DatabaseService.prototype.getLastUpdatedTimeAndTableDataFromAffectedTables = function(node, skip,
+                callback) {
                 return callback(null, {'last_update': new Date('2016-07-01'),
                                        'affected_tables': []});
             };

--- a/test/integration/validator.js
+++ b/test/integration/validator.js
@@ -59,7 +59,7 @@ describe('workflow-validator', function() {
         getColumnNames: createServiceStub([]),
         getColumns: createServiceStub([]),
         getLastUpdatedTimeFromAffectedTables: function(query, skip, callback) {
-            return callback(null, new Date());
+            return callback(null, {'last_update': new Date(), 'affected_tables': []});
         },
         createTableIfNotExists: function(table, query, callback) {
             return callback(null, true);

--- a/test/integration/validator.js
+++ b/test/integration/validator.js
@@ -58,7 +58,7 @@ describe('workflow-validator', function() {
         getSchema: createServiceStub([]),
         getColumnNames: createServiceStub([]),
         getColumns: createServiceStub([]),
-        getLastUpdatedTimeFromAffectedTables: function(query, skip, callback) {
+        getLastUpdatedTimeAndTableDataFromAffectedTables: function(query, skip, callback) {
             return callback(null, {'last_update': new Date(), 'affected_tables': []});
         },
         createTableIfNotExists: function(table, query, callback) {

--- a/test/integration/validator.js
+++ b/test/integration/validator.js
@@ -58,7 +58,7 @@ describe('workflow-validator', function() {
         getSchema: createServiceStub([]),
         getColumnNames: createServiceStub([]),
         getColumns: createServiceStub([]),
-        getLastUpdatedTimeAndTableDataFromAffectedTables: function(query, skip, callback) {
+        getMetadataFromAffectedTables: function(query, skip, callback) {
             return callback(null, {'last_update': new Date(), 'affected_tables': []});
         },
         createTableIfNotExists: function(table, query, callback) {

--- a/test/setup.js
+++ b/test/setup.js
@@ -18,6 +18,7 @@ before(function setupTestDatabase(done) {
         fs.realpathSync('./test/fixtures/cdb_querytables_updated_at.sql'),
         fs.realpathSync('./test/fixtures/cdb_analysis_catalog.sql'),
         fs.realpathSync('./test/fixtures/cdb_analysischeck.sql'),
+        fs.realpathSync('./test/fixtures/cdb_invalidate_varnish.sql'),
 
         fs.realpathSync('./test/fixtures/cdb_dataservices_client/schema.sql'),
         fs.realpathSync('./test/fixtures/cdb_dataservices_client/cdb_geocoder.sql'),

--- a/tools/fake-database-service.js
+++ b/tools/fake-database-service.js
@@ -23,7 +23,7 @@ FakeDatabaseService.prototype = {
         return callback(null);
     },
 
-    getLastUpdatedTimeFromAffectedTables: function(node, skip, callback) {
+    getLastUpdatedTimeAndTableDataFromAffectedTables: function(node, skip, callback) {
         return callback(null, 0);
     },
 

--- a/tools/fake-database-service.js
+++ b/tools/fake-database-service.js
@@ -23,7 +23,7 @@ FakeDatabaseService.prototype = {
         return callback(null);
     },
 
-    getLastUpdatedTimeAndTableDataFromAffectedTables: function(node, skip, callback) {
+    getMetadataFromAffectedTables: function(node, skip, callback) {
         return callback(null, 0);
     },
 


### PR DESCRIPTION
We need to include the affected tables for the source nodes to be used for example to compose the cache headers.

Related cartodb/windshaft-cartodb#629