### PR TITLE
Template support for georeference-street-address' address param

### DIFF
--- a/lib/node/nodes/georeference-street-address.js
+++ b/lib/node/nodes/georeference-street-address.js
@@ -6,7 +6,8 @@ var debug = require('../../util/debug')('analysis:georeference-street-address');
 var TYPE = 'georeference-street-address';
 var PARAMS = {
     source: Node.PARAM.NODE(Node.GEOMETRY.ANY),
-    street_address_column: Node.PARAM.STRING(),
+    street_address_column: Node.PARAM.NULLABLE(Node.PARAM.STRING()),
+    street_address_template: Node.PARAM.NULLABLE(Node.PARAM.STRING()),
     city: Node.PARAM.NULLABLE(Node.PARAM.STRING()),
     city_column: Node.PARAM.NULLABLE(Node.PARAM.STRING()),
     state: Node.PARAM.NULLABLE(Node.PARAM.STRING()),
@@ -15,7 +16,13 @@ var PARAMS = {
     country_column: Node.PARAM.NULLABLE(Node.PARAM.STRING())
 };
 
-var GeoreferenceStreetAddress = Node.create(TYPE, PARAMS, { cache: true });
+var GeoreferenceStreetAddress = Node.create(TYPE, PARAMS, { cache: true,
+    beforeCreate: function(node) {
+        if (node.street_address_column === null && node.street_address_template === null) {
+            throw new Error('Either `street_address_column` or `street_address_template` params must be provided');
+        }
+    }
+});
 
 module.exports = GeoreferenceStreetAddress;
 
@@ -33,7 +40,7 @@ GeoreferenceStreetAddress.prototype.sql = function() {
 
 GeoreferenceStreetAddress.prototype.getGeocoderParams = function () {
     var geocoderParams = [
-        this.getFunctionParam('street_address'),
+        this.getStreetAddressColumnParam(),
         this.getFunctionParam('city'),
         this.getFunctionParam('state'),
         this.getFunctionParam('country')
@@ -42,6 +49,24 @@ GeoreferenceStreetAddress.prototype.getGeocoderParams = function () {
     return geocoderParams;
 };
 
+var COLUMNS_TEMPLATE_REGEX = /\{\{\s*([^\}]*)\}\}/g;
+GeoreferenceStreetAddress.prototype.getStreetAddressColumnParam = function() {
+    if (this.street_address_column) {
+        return this.getFunctionParam('street_address');
+    }
+
+    var columns = [];
+    var result = this.street_address_template.replace(COLUMNS_TEMPLATE_REGEX, function(s, column) {
+        columns.push(column);
+        return '%s';
+    });
+
+    if (columns.length === 0) {
+        return '$tpl$' + this.street_address_template + '$tpl$';
+    }
+
+    return 'format(\''+result+'\', ' + columns.join(', ') + ')';
+};
 
 GeoreferenceStreetAddress.prototype.getFunctionParam = function (name) {
     if (this[name + '_column']) {

--- a/lib/node/nodes/georeference-street-address.js
+++ b/lib/node/nodes/georeference-street-address.js
@@ -49,7 +49,7 @@ GeoreferenceStreetAddress.prototype.getGeocoderParams = function () {
     return geocoderParams;
 };
 
-var COLUMNS_TEMPLATE_REGEX = /\{\{\s*([^\}]*)\}\}/g;
+var COLUMNS_TEMPLATE_REGEX = /\{\{([^\}]*)\}\}/g;
 GeoreferenceStreetAddress.prototype.getStreetAddressColumnParam = function() {
     if (this.street_address_column) {
         return this.getFunctionParam('street_address');
@@ -57,7 +57,7 @@ GeoreferenceStreetAddress.prototype.getStreetAddressColumnParam = function() {
 
     var columns = [];
     var result = this.street_address_template.replace(COLUMNS_TEMPLATE_REGEX, function(s, column) {
-        columns.push(column);
+        columns.push(column.trim());
         return '%s';
     });
 

--- a/lib/node/nodes/georeference-street-address.js
+++ b/lib/node/nodes/georeference-street-address.js
@@ -65,7 +65,7 @@ GeoreferenceStreetAddress.prototype.getStreetAddressColumnParam = function() {
         return '$tpl$' + this.street_address_template + '$tpl$';
     }
 
-    return 'format(\''+result+'\', ' + columns.join(', ') + ')';
+    return 'format($tpl$'+result+'$tpl$, ' + columns.join(', ') + ')';
 };
 
 GeoreferenceStreetAddress.prototype.getFunctionParam = function (name) {

--- a/test/acceptance/georeference-street-address.js
+++ b/test/acceptance/georeference-street-address.js
@@ -1,0 +1,172 @@
+'use strict';
+
+var assert = require('assert');
+var testHelper = require('../helper');
+
+describe('georeference-street-address analysis', function() {
+
+    function quoteColumn(address, column) {
+        return '\'' + address[column] + '\'::text AS ' + column;
+    }
+
+    function addressSourceNode(address) {
+        address = address || {};
+        var columns = ['1 as cartodb_id'].concat(Object.keys(address).map(function(column) {
+            return quoteColumn(address, column);
+        }));
+        return {
+            type: 'source',
+            params: {
+                query: 'SELECT ' + columns.join(', ')
+            }
+        };
+    }
+
+    function wrapQueryWithXY(node) {
+        return [
+            'SELECT *, ST_X(the_geom) AS x, ST_Y(the_geom) AS Y FROM (',
+            node.getQuery(),
+            ') _q'
+        ].join('');
+    }
+
+    it('should check either street_address_column or street_address_column are provided', function (done) {
+        var georeferenceStreetAddressDefinition = {
+            type: 'georeference-street-address',
+            params: {
+                source: addressSourceNode({street_name: ''})
+            }
+        };
+        testHelper.createAnalyses(georeferenceStreetAddressDefinition, function(err) {
+            assert.ok(err);
+            assert.equal(
+                err.message,
+                'Either `street_address_column` or `street_address_template` params must be provided'
+            );
+            done();
+        });
+    });
+
+    var scenarios = [
+        {
+            desc: 'column',
+            addressNode: addressSourceNode({
+                street_name: 'W 26th Street'
+            }),
+            column: 'street_name',
+            x: -74.990425,
+            y: 40.744131
+        },
+        {
+            desc: 'basic template',
+            addressNode: addressSourceNode({
+                street_name: 'W 26th Street'
+            }),
+            template: '{{street_name}}',
+            x: -74.990425,
+            y: 40.744131
+        },
+        {
+            desc: 'template with two columns',
+            addressNode: addressSourceNode({
+                city: 'Madrid',
+                country: 'Spain'
+            }),
+            template: '{{city}}, {{country}}',
+            x: -3.669245,
+            y: 40.429913
+        },
+        {
+            desc: 'template with column and free text',
+            addressNode: addressSourceNode({
+                city: 'Logroño'
+            }),
+            template: '{{city}}, Argentina',
+            x: -61.69614,
+            y: -29.50347
+        },
+        {
+            desc: 'template with spaces in token',
+            addressNode: addressSourceNode({
+                city: 'Logroño'
+            }),
+            template: '{{ city }}, Argentina',
+            x: -61.69614,
+            y: -29.50347
+        },
+        {
+            desc: 'with column and more free text',
+            addressNode: addressSourceNode({
+                city: 'Logroño'
+            }),
+            template: '{{city}}, La Rioja, Spain',
+            x: -2.517555,
+            y: 42.302939
+        },
+        {
+            desc: 'with several columns and free text',
+            addressNode: addressSourceNode({
+                city: 'Logroño',
+                state: 'La Rioja'
+            }),
+            template: '{{city}}, {{state}}, Spain',
+            x: -2.517555,
+            y: 42.302939
+        },
+        {
+            desc: 'with only free text',
+            addressNode: addressSourceNode(),
+            template: 'Logroño, La Rioja, Spain',
+            x: -2.517555,
+            y: 42.302939
+        }
+    ];
+
+    scenarios.forEach(function(scenario) {
+        var testFn = it;
+        if (scenario.test === 'skip') {
+            testFn = it.skip;
+        }
+        if (scenario.test === 'only') {
+            testFn = it.only;
+        }
+
+        testFn('should work from ' + scenario.desc, function (done) {
+            var definition = {
+                type: 'georeference-street-address',
+                params: {
+                    source: scenario.addressNode
+                }
+            };
+
+            if (scenario.column) {
+                definition.params.street_address_column = scenario.column;
+            } else if (scenario.template) {
+                definition.params.street_address_template = scenario.template;
+            } else {
+                return done(new Error('Test scenario is missing `column` and `template`'));
+            }
+
+            testHelper.createAnalyses(definition, function(err, result) {
+                assert.ifError(err);
+
+                var rootNode = result.getRoot();
+
+                testHelper.getRows(wrapQueryWithXY(rootNode), function(err, rows) {
+                    assert.ifError(err);
+                    assert.equal(rows.length, 1);
+                    var row = rows[0];
+
+                    assert.notEqual(row.x, 0, 'X coordinate should not be default=0. Review your scenario.');
+                    assert.notEqual(row.y, 0, 'Y coordinate should not be default=0. Review your scenario.');
+
+                    assert.equal(row.x, scenario.x);
+                    assert.equal(row.y, scenario.y);
+
+                    return done();
+                });
+            });
+        });
+    });
+
+});

--- a/test/fixtures/cdb_dataservices_client/cdb_geocoder.sql
+++ b/test/fixtures/cdb_dataservices_client/cdb_geocoder.sql
@@ -103,11 +103,12 @@ $$ LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION cdb_dataservices_client._cdb_geocode_street_point_exception_safe(searchtext TEXT, city TEXT DEFAULT NULL, state_province TEXT DEFAULT NULL, country TEXT DEFAULT NULL)
 RETURNS Geometry AS $$
-  DECLARE
-    ret Geometry;
-  BEGIN
-    SELECT the_geom INTO ret FROM populated_places_simple WHERE cartodb_id = searchtext::integer LIMIT 1;
-
-    RETURN ret;
-  END
-$$ LANGUAGE plpgsql;
+  SELECT CASE
+    WHEN searchtext = 'W 26th Street' THEN ST_SetSRID(ST_MakePoint(-74.990425, 40.744131), 4326)
+    WHEN searchtext = 'Madrid, Spain' THEN ST_SetSRID(ST_MakePoint(-3.669245, 40.429913), 4326)
+    WHEN searchtext = 'Logroño, Argentina' THEN ST_SetSRID(ST_MakePoint(-61.69614, -29.50347), 4326)
+    WHEN searchtext = 'Logroño, La Rioja, Spain' THEN ST_SetSRID(ST_MakePoint(-2.517555, 42.302939), 4326)
+    ELSE ST_SetSRID(ST_MakePoint(0, 0), 4326)
+    END;
+$$
+LANGUAGE SQL;


### PR DESCRIPTION
It exposes a template system to allow the user to combine multiple
columns and free text in the street_address param.

A client might use something like "{{street_number}} {{street_name}}, Spain",
and it will get transformed into a proper text for the underlying sql query.

This closes #267.