### PR TITLE
Use left join to not lose original geometries from source

### DIFF
--- a/lib/node/nodes/data-observatory-multiple-measures.js
+++ b/lib/node/nodes/data-observatory-multiple-measures.js
@@ -122,6 +122,6 @@ var queryTemplate = Node.template([
     '  ) AS _camshaft_do_measure_analysis_data',
     ')',
     'SELECT {{=it.finalColumns}}',
-    'FROM _data, _source',
-    'WHERE _source.cartodb_id = _data.__obs_id__ '
+    'FROM _source left join _data',
+    'ON _source.cartodb_id = _data.__obs_id__'
 ].join('\n'));


### PR DESCRIPTION
After doing end to end tests in staging I realized that we were losing original geometries from source  when DO does not have data.