### PR TITLE
Do not pass null as string param ("null") to get metadata from DO

### DIFF
--- a/lib/node/nodes/data-observatory-multiple-measures.js
+++ b/lib/node/nodes/data-observatory-multiple-measures.js
@@ -63,10 +63,16 @@ DataObservatoryMultipleMeasures.prototype.sql = function() {
     var obsParams = this.numerators.reduce(function (params, numerator, index) {
         params.push({
             numerator: '"' + numerator + '"',
-            denominator: this.denominators ? '"' + this.denominators[index] + '"' : 'null',
             normalization: '"' + this.normalizations[index]  + '"',
-            geom_id: this.geom_ids ? '"' + this.geom_ids[index] + '"' : 'null',
-            numerator_timespan: this.numerator_timespans ? '"' + this.numerator_timespans[index] + '"' : 'null'
+            denominator: (this.denominators && this.denominators[index]) ?
+                '"' + this.denominators[index] + '"' :
+                'null',
+            geom_id: (this.geom_ids && this.geom_ids[index]) ?
+                '"' + this.geom_ids[index] + '"' :
+                'null',
+            numerator_timespan: (this.numerator_timespans && this.numerator_timespans[index]) ?
+                '"' + this.numerator_timespans[index] + '"' :
+                'null'
         });
 
         return params;

--- a/test/integration/nodes/data-observatory-multiple-measures.js
+++ b/test/integration/nodes/data-observatory-multiple-measures.js
@@ -1,0 +1,80 @@
+'use strict';
+
+var assert = require('assert');
+var Source = require('../../../lib/node/nodes/source');
+var DataObservatoryMultipleMeasures = require('../../../lib/node/nodes/data-observatory-multiple-measures');
+
+describe('data-observatory-multiple-measure', function() {
+
+    var owner = 'localhost';
+    var numerators = ['es.ine.t2_2', 'es.ine.t2_1'];
+    var normalizations = ['denominated', 'denominated'];
+    var denominators = ['es.ine.t1_1', 'es.ine.t1_1'];
+    var geom_ids = ['es.ine.the_geom', 'es.ine.the_geom'];
+    var numerator_timespans = ['2011', '2011'];
+    var columnNames = ['females', 'males'];
+
+    var source = new Source(owner, { query: 'select * from table' });
+
+    it('should not pass null values as string params for DO', function() {
+        var doMeasure = new DataObservatoryMultipleMeasures(owner, {
+            source: source,
+            numerators: numerators,
+            normalizations: normalizations,
+            denominators: [null, null],
+            geom_ids: [null, null],
+            numerator_timespans: [null, null],
+            column_names: columnNames
+        });
+
+        assert.equal(doMeasure.sql().indexOf('"null"'), -1);
+    });
+
+    it('should use "es.ine.t1_1" as denomitator params for DO', function() {
+        var doMeasure = new DataObservatoryMultipleMeasures(owner, {
+            source: source,
+            numerators: numerators,
+            normalizations: normalizations,
+            denominators: denominators,
+            geom_ids: geom_ids,
+            numerator_timespans: numerator_timespans,
+            column_names: columnNames
+        });
+
+        assert.equal(doMeasure.sql().indexOf('"null"'), -1);
+        assert.notEqual(doMeasure.sql().indexOf('"' + denominators[0] + '"'), -1);
+        assert.notEqual(doMeasure.sql().indexOf('"' + denominators[1] + '"'), -1);
+    });
+
+    it('should use "es.ine.the_geom" as geom_id params for DO', function() {
+        var doMeasure = new DataObservatoryMultipleMeasures(owner, {
+            source: source,
+            numerators: numerators,
+            normalizations: normalizations,
+            denominators: denominators,
+            geom_ids: geom_ids,
+            numerator_timespans: numerator_timespans,
+            column_names: columnNames
+        });
+
+        assert.equal(doMeasure.sql().indexOf('"null"'), -1);
+        assert.notEqual(doMeasure.sql().indexOf('"' + geom_ids[0] + '"'), -1);
+        assert.notEqual(doMeasure.sql().indexOf('"' + geom_ids[1] + '"'), -1);
+    });
+
+    it('should use "2011" as numerator_timespan params for DO', function() {
+        var doMeasure = new DataObservatoryMultipleMeasures(owner, {
+            source: source,
+            numerators: numerators,
+            normalizations: normalizations,
+            denominators: denominators,
+            geom_ids: geom_ids,
+            numerator_timespans: numerator_timespans,
+            column_names: columnNames
+        });
+
+        assert.equal(doMeasure.sql().indexOf('"null"'), -1);
+        assert.notEqual(doMeasure.sql().indexOf('"' + numerator_timespans[0] + '"'), -1);
+        assert.notEqual(doMeasure.sql().indexOf('"' + numerator_timespans[1] + '"'), -1);
+    });
+});


### PR DESCRIPTION
This will fix an issue in last release. We were building DO analysis query as follows:

```
cdb_dataservices_client._OBS_GetMeta_exception_safe( extent, ('[{"numer_id": "eu.eurostat.ilc_peps11_pc_pop","denom_id": "null", "normalization": "null","geom_id": "null","numer_timespan": "2013"}]')::JSON, 1, 1, numgeoms )
```

Note that `denom_id`, `normalization` and `geom_id` have `"null"` but they must be `null`. With this hotfix query will be:

```
cdb_dataservices_client._OBS_GetMeta_exception_safe( extent, ('[{"numer_id": "eu.eurostat.ilc_peps11_pc_pop","denom_id": null, "normalization": null,"geom_id": null,"numer_timespan": "2013"}]')::JSON, 1, 1, numgeoms )
```

cc @nobuti 

