### PR TITLE
Add node precheck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Changelog
 
+## 0.56.0
+Released 2017-08-23
 
-## 0.55.9
-Released 2017-mm-dd
+- Add precheck and preexecute hooks for the analysis in order to let the analyses execute some arbitrary
+  condition at instantiation and execution time. See https://github.com/CartoDB/camshaft/pull/317
 
 
 ## 0.55.8

--- a/lib/node/nodes/data-observatory-multiple-measures.js
+++ b/lib/node/nodes/data-observatory-multiple-measures.js
@@ -49,41 +49,26 @@ var DataObservatoryMultipleMeasures = Node.create(TYPE, PARAMS, { cache: true, l
             throw new Error('The number of numerators=' + this.numerators.length +
                 ' does not match the number of numerator_timespans=' + this.numerator_timespans.length);
         }
-    },
+    }
 });
 
 module.exports = DataObservatoryMultipleMeasures;
 
 DataObservatoryMultipleMeasures.prototype._composeObsMetaParams = function() {
-    var obsParams = this.numerators.reduce(function (params, numerator, index) {
-        params.push({
-            numerator: '"' + numerator + '"',
-            normalization: '"' + this.normalizations[index]  + '"',
-            denominator: (this.denominators && this.denominators[index]) ?
-                '"' + this.denominators[index] + '"' :
-                'null',
+    var params = this.numerators.map(function (numerator, index) {
+        return {
+            numer_id: numerator,
+            denom_id: (this.denominators && this.denominators[index]) ?
+                this.denominators[index] : null,
+            normalization: this.normalizations[index],
             geom_id: (this.geom_ids && this.geom_ids[index]) ?
-                '"' + this.geom_ids[index] + '"' :
-                'null',
-            numerator_timespan: (this.numerator_timespans && this.numerator_timespans[index]) ?
-                '"' + this.numerator_timespans[index] + '"' :
-                'null'
-        });
+                this.geom_ids[index] : null,
+            numer_timespan: (this.numerator_timespans && this.numerator_timespans[index]) ?
+                this.numerator_timespans[index] : null
+        };
+    }.bind(this));
 
-        return params;
-    }.bind(this), []);
-
-    return obsParams.map(function (arg) {
-        return [
-            '{',
-                '"numer_id": ' + arg.numerator + ',',
-                '"denom_id": ' + arg.denominator + ',',
-                '"normalization": ' + arg.normalization + ',',
-                '"geom_id": ' + arg.geom_id + ',',
-                '"numer_timespan": ' + arg.numerator_timespan,
-            '}'
-        ].join('');
-    }).join(',');
+    return JSON.stringify(params);
 };
 
 DataObservatoryMultipleMeasures.prototype.sql = function() {
@@ -137,11 +122,12 @@ var queryTemplate = Node.template([
     'ON _source.cartodb_id = _data.__obs_id__'
 ].join('\n'));
 
+var preCheckQueryTemplate = Node.template([
+    'SELECT cdb_dataservices_client._OBS_PreCheck(\'{{=it.source}}\',',
+    ' \'{{=it.obsMetaParams}}\'::json)'
+].join(''));
+
 DataObservatoryMultipleMeasures.prototype.preCheckQuery = function() {
-    var preCheckQueryTemplate = Node.template([
-        'SELECT cdb_dataservices_client._OBS_PreCheck(\'{{=it.source}}\',',
-        ' \'{{=it.obsMetaParams}}\'::jsonb)'
-    ].join(''));
     var sql = preCheckQueryTemplate({
         source: this.source.getQuery(false),
         obsMetaParams: this._composeObsMetaParams()

--- a/lib/node/nodes/data-observatory-multiple-measures.js
+++ b/lib/node/nodes/data-observatory-multiple-measures.js
@@ -106,7 +106,7 @@ var queryTemplate = Node.template([
     '  SELECT',
     '    cdb_dataservices_client._OBS_GetMeta_exception_safe(',
     '      extent,',
-    '      (\'[{{=it.obsMetaParams}}]\')::JSON, 1, 1, numgeoms',
+    '      (\'{{=it.obsMetaParams}}\')::JSON, 1, 1, numgeoms',
     '    ) as meta',
     '  FROM _summary',
     '),',

--- a/lib/node/nodes/data-observatory-multiple-measures.js
+++ b/lib/node/nodes/data-observatory-multiple-measures.js
@@ -49,17 +49,12 @@ var DataObservatoryMultipleMeasures = Node.create(TYPE, PARAMS, { cache: true, l
             throw new Error('The number of numerators=' + this.numerators.length +
                 ' does not match the number of numerator_timespans=' + this.numerator_timespans.length);
         }
-    }
+    },
 });
 
 module.exports = DataObservatoryMultipleMeasures;
 
-DataObservatoryMultipleMeasures.prototype.sql = function() {
-    var finalColumns = ['_source.*']
-        .concat(this.column_names.map(function(columnName) {
-            return '_data.' + columnName;
-        })).join(', ');
-
+DataObservatoryMultipleMeasures.prototype._composeObsMetaParams = function() {
     var obsParams = this.numerators.reduce(function (params, numerator, index) {
         params.push({
             numerator: '"' + numerator + '"',
@@ -78,22 +73,31 @@ DataObservatoryMultipleMeasures.prototype.sql = function() {
         return params;
     }.bind(this), []);
 
+    return obsParams.map(function (arg) {
+        return [
+            '{',
+                '"numer_id": ' + arg.numerator + ',',
+                '"denom_id": ' + arg.denominator + ',',
+                '"normalization": ' + arg.normalization + ',',
+                '"geom_id": ' + arg.geom_id + ',',
+                '"numer_timespan": ' + arg.numerator_timespan,
+            '}'
+        ].join('');
+    }).join(',');
+};
+
+DataObservatoryMultipleMeasures.prototype.sql = function() {
+    var finalColumns = ['_source.*']
+        .concat(this.column_names.map(function(columnName) {
+            return '_data.' + columnName;
+        })).join(', ');
+
     var sql = queryTemplate({
         source: this.source.getQuery(false),
         obsColumns: this.column_names.map(function (columnName, index) {
             return '(data->' + index + '->>\'value\')::Numeric AS ' + columnName;
         }).join(', '),
-        obsMetaParams: obsParams.map(function (arg) {
-            return [
-                '{',
-                    '"numer_id": ' + arg.numerator + ',',
-                    '"denom_id": ' + arg.denominator + ',',
-                    '"normalization": ' + arg.normalization + ',',
-                    '"geom_id": ' + arg.geom_id + ',',
-                    '"numer_timespan": ' + arg.numerator_timespan,
-                '}'
-            ].join('');
-        }).join(','),
+        obsMetaParams: this._composeObsMetaParams(),
         finalColumns: finalColumns
     });
 
@@ -132,3 +136,16 @@ var queryTemplate = Node.template([
     'FROM _source left join _data',
     'ON _source.cartodb_id = _data.__obs_id__'
 ].join('\n'));
+
+DataObservatoryMultipleMeasures.prototype.preCheckQuery = function() {
+    var preCheckQueryTemplate = Node.template([
+        'SELECT cdb_dataservices_client._OBS_PreCheck(\'{{=it.source}}\',',
+        ' \'{{=it.obsMetaParams}}\'::jsonb)'
+    ].join(''));
+    var sql = preCheckQueryTemplate({
+        source: this.source.getQuery(false),
+        obsMetaParams: this._composeObsMetaParams()
+    });
+    debug(sql);
+    return sql;
+};

--- a/lib/postgresql/node-sql-adapter.js
+++ b/lib/postgresql/node-sql-adapter.js
@@ -47,3 +47,9 @@ NodeSqlAdapter.prototype.analyzeTableQuery = function() {
 NodeSqlAdapter.prototype.annotatedNodeType = function() {
     return '/* analysis:' + this.node.getType() + ' */';
 };
+
+NodeSqlAdapter.prototype.preCheckNodeQuery = function() {
+    if (this.node.preCheckQuery) {
+        return this.node.preCheckQuery();
+    }
+};

--- a/lib/service/database.js
+++ b/lib/service/database.js
@@ -211,6 +211,10 @@ function transactionQuery(queries) {
     return ['BEGIN'].concat(queries).concat('COMMIT').join(';') + ';';
 }
 
+function readOnlyTransactionQuery(queries) {
+    return ['BEGIN;SET TRANSACTION READ ONLY'].concat(queries).concat('COMMIT').join(';') + ';';
+}
+
 function invalidateCache(targetTableNames) {
     var invalidations = targetTableNames.map(function(tableName) {
        return 'cdb_invalidate_varnish(\'' + tableName + '\')';
@@ -284,6 +288,12 @@ DatabaseService.prototype.queueAnalysisOperations = function(analysis, callback)
                 asyncQueries.push({
                     query: updateNodeStatusAtAnalysisCatalogQuery(nodeIds, Node.STATUS.RUNNING)
                 });
+                if (sqlWrappedNode.preCheckNodeQuery() !== undefined) {
+                    asyncQueries.push({
+                        query: readOnlyTransactionQuery([sqlWrappedNode.preCheckNodeQuery()]),
+                        onerror: updateNodeAtAnalysisCatalogForJobResultQuery(nodeIds, Node.STATUS.FAILED, true)
+                    });
+                }
                 asyncQueries.push({
                     id: asyncQueryId(analysis, nodeToUpdate),
                     timeout: nodeToUpdate.getCacheQueryTimeout(),

--- a/lib/workflow/factory.js
+++ b/lib/workflow/factory.js
@@ -5,15 +5,15 @@ var Node = require('../node/node');
 var async = require('async');
 var debug = require('../util/debug')('factory');
 
-var typeNodeMap = nodes.reduce(function(typeNodeMap, node) {
+var DEFAULT_TYPE_NODE_MAP = nodes.reduce(function(typeNodeMap, node) {
     typeNodeMap[node.TYPE] = node;
     return typeNodeMap;
 }, {});
 
-function Factory(user, databaseService) {
+function Factory(user, databaseService, typeNodeMap) {
     this.user = user;
     this.databaseService = databaseService;
-    this.typeNodeMap = typeNodeMap;
+    this.typeNodeMap = typeNodeMap || DEFAULT_TYPE_NODE_MAP;
 }
 
 module.exports = Factory;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "camshaft",
-  "version": "0.55.8",
+  "version": "0.56.0",
   "description": "Analysis library to create data views from queries",
   "main": "./lib/analysis.js",
   "scripts": {

--- a/test/fixtures/cdb_dataservices_client/cdb_precheck.sql
+++ b/test/fixtures/cdb_dataservices_client/cdb_precheck.sql
@@ -1,0 +1,8 @@
+CREATE OR REPLACE FUNCTION cdb_dataservices_client._OBS_PreCheck(
+    source_query text,
+    parameters json
+) RETURNS boolean AS $$
+BEGIN
+  RETURN TRUE;
+END;
+$$ LANGUAGE 'plpgsql' IMMUTABLE STRICT;

--- a/test/integration/analysis.js
+++ b/test/integration/analysis.js
@@ -166,7 +166,7 @@ describe('workflow', function() {
             });
         });
 
-        it.only('PRECHECK query should be inside a read-only transaction', function(done) {
+        it('PRECHECK query should be inside a read-only transaction', function(done) {
             var enqueueFn = BatchClient.prototype.enqueue;
 
             var enqueueCalled = false;

--- a/test/integration/analysis.js
+++ b/test/integration/analysis.js
@@ -74,7 +74,7 @@ describe('workflow', function() {
             Analysis.create(testConfig, tradeAreaAnalysisDefinition, function(err, analysis) {
                 BatchClient.prototype.enqueue = enqueueFn;
 
-                assert.ok(!err, err);
+                assert.ifError(err);
                 assert.ok(enqueueCalled);
 
                 var rootNode = analysis.getRoot();
@@ -102,7 +102,7 @@ describe('workflow', function() {
             Analysis.create(testConfig, tradeAreaAnalysisDefinition, function(err, analysis) {
                 BatchClient.prototype.enqueue = enqueueFn;
 
-                assert.ok(!err, err);
+                assert.ifError(err);
                 assert.ok(enqueueCalled);
 
                 var nodeBuffer = analysis.getNodes()[0];
@@ -126,7 +126,7 @@ describe('workflow', function() {
             Analysis.create(testConfig, tradeAreaAnalysisDefinition, function(err) {
                 BatchClient.prototype.enqueue = enqueueFn;
 
-                assert.ok(!err, err);
+                assert.ifError(err);
                 assert.ok(enqueueCalled);
                 assert.ok(invalidateQuery.match(
                     new RegExp('select cdb_invalidate_varnish\\(\'public.atm_machines\'\\)', 'i')
@@ -148,15 +148,15 @@ describe('workflow', function() {
             };
 
             Analysis.create(testConfig, doAnalysisDefinition, function(err) {
-                assert.ok(!err, err);
+                assert.ifError(err);
                 BatchClient.prototype.enqueue = enqueueFn;
                 assert.ok(enqueueCalled);
                 var expectedPreCheckQuery = [
                     'BEGIN;SET TRANSACTION READ ONLY;',
                     'SELECT cdb_dataservices_client._OBS_PreCheck(\'select * from atm_machines\',',
-                    ' \'{"numer_id": "test.numerator","denom_id": "test.denominator",',
-                    '"normalization": "prenormalized","geom_id": "test.geoids",',
-                    '"numer_timespan": "test.timespan"}\'::jsonb);COMMIT;'
+                    ' \'[{"numer_id":"test.numerator","denom_id":"test.denominator",',
+                    '"normalization":"prenormalized","geom_id":"test.geoids",',
+                    '"numer_timespan":"test.timespan"}]\'::json);COMMIT;'
                 ].join('');
                 assert.equal(lastEnqueuedQuery,expectedPreCheckQuery);
 
@@ -296,7 +296,7 @@ describe('operations', function() {
 
     it('should return two nodes', function(done) {
         Analysis.create(testConfig, tradeAreaAnalysisDefinition, function(err, analysis) {
-            assert.ok(!err, err);
+            assert.ifError(err);
             assert.equal(analysis.getNodes().length, 2);
             done();
         });
@@ -304,7 +304,7 @@ describe('operations', function() {
 
     it('should return just one node', function(done) {
         Analysis.create(testConfig, sourceAnalysisDefinition, function(err, analysis) {
-            assert.ok(!err, err);
+            assert.ifError(err);
             assert.equal(analysis.getNodes().length, 1);
             done();
         });

--- a/test/integration/analysis.js
+++ b/test/integration/analysis.js
@@ -39,6 +39,19 @@ describe('workflow', function() {
             }
         };
 
+        var doAnalysisDefinition = {
+            type: 'data-observatory-multiple-measures',
+            params: {
+                source: sourceAnalysisDefinition,
+                numerators: ['test.numerator'],
+                normalizations: ['prenormalized'],
+                denominators: ['test.denominator'],
+                geom_ids: ['test.geoids'],
+                numerator_timespans: ['test.timespan'],
+                column_names: ['test_column']
+            }
+        };
+
         it('should work for basic source analysis', function(done) {
             Analysis.create(testConfig, sourceAnalysisDefinition, function(err, analysis) {
                 assert.ok(!err, err);
@@ -61,9 +74,9 @@ describe('workflow', function() {
             Analysis.create(testConfig, tradeAreaAnalysisDefinition, function(err, analysis) {
                 BatchClient.prototype.enqueue = enqueueFn;
 
+                assert.ok(!err, err);
                 assert.ok(enqueueCalled);
 
-                assert.ok(!err, err);
                 var rootNode = analysis.getRoot();
                 assert.ok(analysis.getQuery().match(new RegExp('select\\s\\*\\sfrom ' + rootNode.getTargetTable())));
 
@@ -89,8 +102,8 @@ describe('workflow', function() {
             Analysis.create(testConfig, tradeAreaAnalysisDefinition, function(err, analysis) {
                 BatchClient.prototype.enqueue = enqueueFn;
 
-                assert.ok(enqueueCalled);
                 assert.ok(!err, err);
+                assert.ok(enqueueCalled);
 
                 var nodeBuffer = analysis.getNodes()[0];
                 assert.ok(lastEnqueuedQuery.match(new RegExp('ANALYZE ' + nodeBuffer.getTargetTable() + ';')));
@@ -113,11 +126,39 @@ describe('workflow', function() {
             Analysis.create(testConfig, tradeAreaAnalysisDefinition, function(err) {
                 BatchClient.prototype.enqueue = enqueueFn;
 
-                assert.ok(enqueueCalled);
                 assert.ok(!err, err);
+                assert.ok(enqueueCalled);
                 assert.ok(invalidateQuery.match(
                     new RegExp('select cdb_invalidate_varnish\\(\'public.atm_machines\'\\)', 'i')
                 ));
+
+                done();
+            });
+        });
+
+        it('should execute PRECHECK query if defined in the analysis node', function(done) {
+            var enqueueFn = BatchClient.prototype.enqueue;
+
+            var enqueueCalled = false;
+            var lastEnqueuedQuery = null;
+            BatchClient.prototype.enqueue = function(query, callback) {
+                enqueueCalled = true;
+                lastEnqueuedQuery = query[2].query;
+                return callback(null, {status: 'ok'});
+            };
+
+            Analysis.create(testConfig, doAnalysisDefinition, function(err) {
+                assert.ok(!err, err);
+                BatchClient.prototype.enqueue = enqueueFn;
+                assert.ok(enqueueCalled);
+                var expectedPreCheckQuery = [
+                    'BEGIN;SET TRANSACTION READ ONLY;',
+                    'SELECT cdb_dataservices_client._OBS_PreCheck(\'select * from atm_machines\',',
+                    ' \'{"numer_id": "test.numerator","denom_id": "test.denominator",',
+                    '"normalization": "prenormalized","geom_id": "test.geoids",',
+                    '"numer_timespan": "test.timespan"}\'::jsonb);COMMIT;'
+                ].join('');
+                assert.equal(lastEnqueuedQuery,expectedPreCheckQuery);
 
                 done();
             });

--- a/test/integration/factory.js
+++ b/test/integration/factory.js
@@ -1,0 +1,54 @@
+'use strict';
+
+var assert = require('assert');
+
+var Node = require('../../lib/node/node');
+var DatabaseService = require('../../lib/service/database');
+var Factory = require('../../lib/workflow/factory');
+
+var TestConfig = require('../test-config');
+
+describe('factory', function() {
+
+    before(function() {
+        var configuration = TestConfig.create({ batch: { inlineExecution: true } });
+        this.configuration = configuration;
+        this.databaseService = new DatabaseService(
+            configuration.user,
+            configuration.db,
+            configuration.batch,
+            configuration.limits
+        );
+    });
+
+    it('basic test-source node', function(done) {
+        var TEST_SOURCE_TYPE = 'test-source';
+        var TestSource = Node.create(TEST_SOURCE_TYPE, {
+            table: Node.PARAM.STRING()
+        }, { cache: true });
+        TestSource.prototype.sql = function() {
+            return 'select * from ' + this.table;
+        };
+
+        var definition = {
+            type: TEST_SOURCE_TYPE,
+            params: {
+                table: 'airbnb_rooms'
+            }
+        };
+
+        var typeNodeMap = {};
+        typeNodeMap[TEST_SOURCE_TYPE] = TestSource;
+
+        var factory = new Factory(this.configuration.user, this.databaseService, typeNodeMap);
+        factory.create(definition, function(err, rootNode) {
+            assert.ifError(err);
+
+            assert.equal(rootNode.getType(), TEST_SOURCE_TYPE);
+            assert.equal(rootNode.sql(), 'select * from airbnb_rooms');
+            assert.ok(rootNode.getQuery().match(/^select \* from analysis_/));
+
+            return done();
+        });
+    });
+});

--- a/test/setup.js
+++ b/test/setup.js
@@ -28,6 +28,7 @@ before(function setupTestDatabase(done) {
         fs.realpathSync('./test/fixtures/cdb_dataservices_client/cdb_route_point_to_point.sql'),
         fs.realpathSync('./test/fixtures/cdb_dataservices_client/cdb_route_with_waypoints.sql'),
         fs.realpathSync('./test/fixtures/cdb_dataservices_client/obs_getmeasure.sql'),
+        fs.realpathSync('./test/fixtures/cdb_dataservices_client/cdb_precheck.sql'),
 
         fs.realpathSync('./test/fixtures/cdb_crankshaft/schema.sql'),
         fs.realpathSync('./test/fixtures/cdb_crankshaft/cdb_kmeans.sql'),


### PR DESCRIPTION
**We need to have the _OBS_PreCheck function in the DS client part before deploying this change**

In order to be able to make pre-checks of the data that is going to be used in the analysis, I've added a `preCheckQuery` option that is executed before the main query for the analysis and inside a `READ ONLY` transaction to avoid security problems.

This PR is more to check the validity of this approach. I've tested in my local environment and it works. Analysis without precheck works fine and the cases of my precheck works too. 

Some examples

![captura de pantalla 2017-08-07 13 26 07](https://user-images.githubusercontent.com/741240/29033395-39ae9830-7b95-11e7-931a-4900b3fca5dd.png)
![captura de pantalla 2017-08-07 13 44 39 2](https://user-images.githubusercontent.com/741240/29033399-3fe631cc-7b95-11e7-8019-0c46b38ff8ed.png)
