### PR TITLE
Bind node itself in beforeCreate function for better semantics

### DIFF
--- a/lib/node/node.js
+++ b/lib/node/node.js
@@ -449,7 +449,7 @@ module.exports.create = function createNode(type, expectedParams, options) {
         // `beforeCreate` allows to change/modify the node before it's actually created/returned
         // if it throws an error it will fail to create the node.
         if (options.beforeCreate) {
-            options.beforeCreate(this);
+            options.beforeCreate.bind(this)();
         }
         this.validators = Array.isArray(options.validators) ? options.validators : [];
     }

--- a/lib/node/nodes/bounding-box.js
+++ b/lib/node/nodes/bounding-box.js
@@ -11,8 +11,8 @@ var PARAMS = {
 };
 
 var BoundingBox = Node.create(TYPE, PARAMS, { version: 1,
-    beforeCreate: function(node) {
-        if (node.aggregation !== 'count' && node.aggregation_column === null) {
+    beforeCreate: function() {
+        if (this.aggregation !== 'count' && this.aggregation_column === null) {
             throw new Error('Param `aggregation` != "count" requires an existent `aggregation_column` column');
         }
     }

--- a/lib/node/nodes/bounding-circle.js
+++ b/lib/node/nodes/bounding-circle.js
@@ -11,8 +11,8 @@ var PARAMS = {
 };
 
 var BoundingCircle = Node.create(TYPE, PARAMS, { version: 1,
-    beforeCreate: function(node) {
-        if (node.aggregation !== 'count' && node.aggregation_column === null) {
+    beforeCreate: function() {
+        if (this.aggregation !== 'count' && this.aggregation_column === null) {
             throw new Error('Param `aggregation` != "count" requires an existent `aggregation_column` column');
         }
     }

--- a/lib/node/nodes/concave-hull.js
+++ b/lib/node/nodes/concave-hull.js
@@ -13,8 +13,8 @@ var PARAMS = {
 };
 
 var ConcaveHull = Node.create(TYPE, PARAMS, { version: 1,
-    beforeCreate: function(node) {
-        if (node.aggregation !== 'count' && node.aggregation_column === null) {
+    beforeCreate: function() {
+        if (this.aggregation !== 'count' && this.aggregation_column === null) {
             throw new Error('Param `aggregation` != "count" requires an existent `aggregation_column` column');
         }
     }

--- a/lib/node/nodes/convex-hull.js
+++ b/lib/node/nodes/convex-hull.js
@@ -11,8 +11,8 @@ var PARAMS = {
 };
 
 var ConvexHull = Node.create(TYPE, PARAMS, { version: 1,
-    beforeCreate: function(node) {
-        if (node.aggregation !== 'count' && node.aggregation_column === null) {
+    beforeCreate: function() {
+        if (this.aggregation !== 'count' && this.aggregation_column === null) {
             throw new Error('Param `aggregation` != "count" requires an existent `aggregation_column` column');
         }
     }

--- a/lib/node/nodes/data-observatory-multiple-measures.js
+++ b/lib/node/nodes/data-observatory-multiple-measures.js
@@ -15,39 +15,39 @@ var PARAMS = {
 };
 
 var DataObservatoryMultipleMeasures = Node.create(TYPE, PARAMS, { cache: true, lazy: true,
-    beforeCreate: function(node) {
+    beforeCreate: function() {
         /* jshint maxcomplexity:8 */
-        if (node.numerators.length === 0) {
+        if (this.numerators.length === 0) {
             throw new Error('The numerators array cannot be empty');
         }
 
-        if (node.numerators.length !== node.column_names.length) {
-            throw new Error('The number of numerators=' + node.numerators.length +
-                ' does not match the number of column_names=' + node.column_names.length);
+        if (this.numerators.length !== this.column_names.length) {
+            throw new Error('The number of numerators=' + this.numerators.length +
+                ' does not match the number of column_names=' + this.column_names.length);
         }
 
-        if (node.normalizations.length === 0) {
+        if (this.normalizations.length === 0) {
             throw new Error('The normalizations array cannot be empty');
         }
 
-        if (node.normalizations.length !== node.numerators.length) {
-            throw new Error('The number of numerators=' + node.numerators.length +
-                ' does not match the number of normalizations=' + node.normalizations.length);
+        if (this.normalizations.length !== this.numerators.length) {
+            throw new Error('The number of numerators=' + this.numerators.length +
+                ' does not match the number of normalizations=' + this.normalizations.length);
         }
 
-        if (node.denominators && node.denominators.length !== node.numerators.length) {
-            throw new Error('The number of numerators=' + node.numerators.length +
-                ' does not match the number of denominators=' + node.denominators.length);
+        if (this.denominators && this.denominators.length !== this.numerators.length) {
+            throw new Error('The number of numerators=' + this.numerators.length +
+                ' does not match the number of denominators=' + this.denominators.length);
         }
 
-        if (node.geom_ids && node.geom_ids.length !== node.numerators.length) {
-            throw new Error('The number of numerators=' + node.numerators.length +
-                ' does not match the number of geom_ids=' + node.geom_ids.length);
+        if (this.geom_ids && this.geom_ids.length !== this.numerators.length) {
+            throw new Error('The number of numerators=' + this.numerators.length +
+                ' does not match the number of geom_ids=' + this.geom_ids.length);
         }
 
-        if (node.numerator_timespans && node.numerator_timespans.length !== node.numerators.length) {
-            throw new Error('The number of numerators=' + node.numerators.length +
-                ' does not match the number of numerator_timespans=' + node.numerator_timespans.length);
+        if (this.numerator_timespans && this.numerator_timespans.length !== this.numerators.length) {
+            throw new Error('The number of numerators=' + this.numerators.length +
+                ' does not match the number of numerator_timespans=' + this.numerator_timespans.length);
         }
     }
 });

--- a/lib/node/nodes/deprecated-sql-function.js
+++ b/lib/node/nodes/deprecated-sql-function.js
@@ -13,8 +13,8 @@ var PARAMS = {
 };
 
 var DeprecatedSqlFunction = Node.create(TYPE, PARAMS, { cache: true,
-    beforeCreate: function(node) {
-        if (!node.function_name.match(/^DEP_EXT_/)) {
+    beforeCreate: function() {
+        if (!this.function_name.match(/^DEP_EXT_/)) {
             throw new Error('Invalid "function_name" param: it must start with `DEP_EXT_`');
         }
     },

--- a/lib/node/nodes/filter-category.js
+++ b/lib/node/nodes/filter-category.js
@@ -12,10 +12,10 @@ var PARAMS = {
 };
 
 var FilterCategory = Node.create(TYPE, PARAMS, {
-    beforeCreate: function (node) {
-        node.category = new Category({ name: node.column }, {
-            accept: node.accept,
-            reject: node.reject
+    beforeCreate: function () {
+        this.category = new Category({ name: this.column }, {
+            accept: this.accept,
+            reject: this.reject
         });
     }
 });

--- a/lib/node/nodes/filter-grouped-rank.js
+++ b/lib/node/nodes/filter-grouped-rank.js
@@ -14,12 +14,12 @@ var PARAMS = {
 };
 
 var FilterGroupedRank = Node.create(TYPE, PARAMS, { cache: true,
-    beforeCreate: function (node) {
-        node.groupedRank = new GroupedRank({ name: node.column }, {
-            rank: node.rank,
-            group: node.group,
-            min: node.min,
-            max: node.max
+    beforeCreate: function () {
+        this.groupedRank = new GroupedRank({ name: this.column }, {
+            rank: this.rank,
+            group: this.group,
+            min: this.min,
+            max: this.max
         });
     }
 });

--- a/lib/node/nodes/filter-range.js
+++ b/lib/node/nodes/filter-range.js
@@ -12,10 +12,10 @@ var PARAMS = {
 };
 
 var FilterRange = Node.create(TYPE, PARAMS, {
-    beforeCreate: function (node) {
-        node.range = new Range({ name: node.column }, {
-            min: node.min,
-            max: node.max
+    beforeCreate: function () {
+        this.range = new Range({ name: this.column }, {
+            min: this.min,
+            max: this.max
         });
     }
 });

--- a/lib/node/nodes/filter-rank.js
+++ b/lib/node/nodes/filter-rank.js
@@ -13,11 +13,11 @@ var PARAMS = {
 };
 
 var FilterRank = Node.create(TYPE, PARAMS, { cache: true,
-    beforeCreate: function (node) {
-        node.rank = new Rank({ name: node.column }, {
-            rank: node.rank,
-            limit: node.limit,
-            action: node.action
+    beforeCreate: function () {
+        this.rank = new Rank({ name: this.column }, {
+            rank: this.rank,
+            limit: this.limit,
+            action: this.action
         });
     }
 });

--- a/lib/node/nodes/georeference-city.js
+++ b/lib/node/nodes/georeference-city.js
@@ -15,8 +15,8 @@ var PARAMS = {
 
 var GeoreferenceCity = Node.create(TYPE, PARAMS, {
     cache: true,
-    beforeCreate: function (node) {
-        if (node.getFunctionParam('admin_region') && !node.getFunctionParam('country')) {
+    beforeCreate: function () {
+        if (this.getFunctionParam('admin_region') && !this.getFunctionParam('country')) {
             throw new Error('Missing required param "country".' +
                 ' Param "admin_region" must be used along with "country" param');
         }

--- a/lib/node/nodes/georeference-postal-code.js
+++ b/lib/node/nodes/georeference-postal-code.js
@@ -18,8 +18,8 @@ var PARAMS = {
 
 var GeoreferencePostalCode = Node.create(TYPE, PARAMS, {
     cache: true,
-    beforeCreate: function (node) {
-        if (!node.country && !node.country_column) {
+    beforeCreate: function () {
+        if (!this.country && !this.country_column) {
             throw new Error('You must indicate "country" or "country_column" param');
         }
     }

--- a/lib/node/nodes/georeference-street-address.js
+++ b/lib/node/nodes/georeference-street-address.js
@@ -17,8 +17,8 @@ var PARAMS = {
 };
 
 var GeoreferenceStreetAddress = Node.create(TYPE, PARAMS, { cache: true,
-    beforeCreate: function(node) {
-        if (node.street_address_column === null && node.street_address_template === null) {
+    beforeCreate: function() {
+        if (this.street_address_column === null && this.street_address_template === null) {
             throw new Error('Either `street_address_column` or `street_address_template` params must be provided');
         }
     }

--- a/lib/node/nodes/gravity.js
+++ b/lib/node/nodes/gravity.js
@@ -17,11 +17,11 @@ var PARAMS = {
 var Gravity = Node.create(TYPE, PARAMS, {
     cache: true,
     version: 1,
-    beforeCreate: function (node) {
-        if (node.weight_threshold < -10e307) {
+    beforeCreate: function () {
+        if (this.weight_threshold < -10e307) {
             throw new Error('weight_threshold param should be bigger than -10e307');
         }
-        if (node.weight_threshold > 10e307) {
+        if (this.weight_threshold > 10e307) {
             throw new Error('weight_threshold param should be bigger than 10e307');
         }
     }

--- a/lib/node/nodes/line-source-to-target.js
+++ b/lib/node/nodes/line-source-to-target.js
@@ -22,12 +22,12 @@ var PARAMS = {
 var LineSourceToTarget = Node.create(TYPE, PARAMS, {
     version: 2,
     cache: true,
-    beforeCreate: function (node) {
-        if (!node.source_column && node.target_column) {
+    beforeCreate: function () {
+        if (!this.source_column && this.target_column) {
             throw new Error('Missing param `source_column`');
         }
 
-        if (node.source_column && !node.target_column) {
+        if (this.source_column && !this.target_column) {
             throw new Error('Missing param `target_column`');
         }
     }

--- a/lib/node/nodes/moran.js
+++ b/lib/node/nodes/moran.js
@@ -17,13 +17,13 @@ var PARAMS = {
 };
 
 var Moran = Node.create(TYPE, PARAMS, { cache: true, version: 2, tags: ['cpu2x'],
-    beforeCreate: function(node) {
-        node.ignoreParamForId('significance');
-        node.filters.__significance__ = {
+    beforeCreate: function() {
+        this.ignoreParamForId('significance');
+        this.filters.__significance__ = {
             type: 'range',
             column: 'significance',
             params: {
-                max: node.significance
+                max: this.significance
             }
         };
     }

--- a/lib/node/nodes/routing-to-layer-all-to-all.js
+++ b/lib/node/nodes/routing-to-layer-all-to-all.js
@@ -18,14 +18,14 @@ var PARAMS = {
 };
 
 var RoutingToLayerAllToAll = Node.create(TYPE, PARAMS, { cache: true,
-    beforeCreate: function (node) {
-        if (node.closest) {
-            node.ignoreParamForId('duration');
-            node.filters.__duration__ = {
+    beforeCreate: function () {
+        if (this.closest) {
+            this.ignoreParamForId('duration');
+            this.filters.__duration__ = {
                 type: 'grouped-rank',
                 column: 'duration',
                 params: {
-                    group: node.source_column,
+                    group: this.source_column,
                     rank: 'bottom',
                     max: 1
                 }

--- a/lib/node/nodes/source.js
+++ b/lib/node/nodes/source.js
@@ -8,13 +8,13 @@ var PARAMS = {
 };
 
 var Source = Node.create(TYPE, PARAMS, {
-    beforeCreate: function(node) {
+    beforeCreate: function() {
         // Last updated time in source node means data changed so it has to modify node.id
-        node.setAttributeToModifyId('updatedAt');
+        this.setAttributeToModifyId('updatedAt');
         // Columns have to modify Node.id().
         // When a `select * from table` might end in a different set of columns we want to have a different node.
         // Current table triggers don't check DDL changes.
-        node.setAttributeToModifyId('columns');
+        this.setAttributeToModifyId('columns');
     }
 });
 

--- a/test/unit/node-creation.js
+++ b/test/unit/node-creation.js
@@ -300,8 +300,8 @@ describe('node-creation', function() {
     describe('Node custom validate', function() {
         var validList = [1, 2, 3, 4];
         var CustomValidationNode = Node.create('test-custom-validation', { list: Node.PARAM.ARRAY() }, {
-            beforeCreate: function(node) {
-                assert.deepEqual(node.list, validList, 'Custom validation throws this');
+            beforeCreate: function() {
+                assert.deepEqual(this.list, validList, 'Custom validation throws this');
             }
         });
 
@@ -329,8 +329,8 @@ describe('node-creation', function() {
         var ANode = Node.create('test-a-with-ignored-b', { a: Node.PARAM.STRING() });
         var ABNode = Node.create('test-a-with-ignored-b', { a: Node.PARAM.STRING(), b: Node.PARAM.STRING() });
         var AIgnoredBNode = Node.create('test-a-with-ignored-b', { a: Node.PARAM.STRING(), b: Node.PARAM.STRING() }, {
-            beforeCreate: function(node) {
-                node.ignoreParamForId('b');
+            beforeCreate: function() {
+                this.ignoreParamForId('b');
             }
         });
 

--- a/test/unit/node-updated-at.js
+++ b/test/unit/node-updated-at.js
@@ -22,8 +22,8 @@ describe('node-updated-at', function() {
     var START_TIME = new Date('1970-01-01T00:00:00.000Z');
 
     var FooSourceNode = Node.create('foo-source', { buster: Node.PARAM.STRING() }, {
-        beforeCreate: function(node) {
-            node.setUpdatedAt(START_TIME);
+        beforeCreate: function() {
+            this.setUpdatedAt(START_TIME);
         }
     });
 


### PR DESCRIPTION
It's easier to understand what you are affecting when you work
with `this` instead with a pass by reference `node` variable.

This will align with other hooks like one for being able to execute
an arbitrary query before creating the node to ensure/validate some
metadata is present in the created node.