### PR TITLE
Factory can accept an optional map for node types/implementations

### DIFF
--- a/lib/workflow/factory.js
+++ b/lib/workflow/factory.js
@@ -5,15 +5,15 @@ var Node = require('../node/node');
 var async = require('async');
 var debug = require('../util/debug')('factory');
 
-var typeNodeMap = nodes.reduce(function(typeNodeMap, node) {
+var DEFAULT_TYPE_NODE_MAP = nodes.reduce(function(typeNodeMap, node) {
     typeNodeMap[node.TYPE] = node;
     return typeNodeMap;
 }, {});
 
-function Factory(user, databaseService) {
+function Factory(user, databaseService, typeNodeMap) {
     this.user = user;
     this.databaseService = databaseService;
-    this.typeNodeMap = typeNodeMap;
+    this.typeNodeMap = typeNodeMap || DEFAULT_TYPE_NODE_MAP;
 }
 
 module.exports = Factory;

--- a/test/integration/factory.js
+++ b/test/integration/factory.js
@@ -1,0 +1,54 @@
+'use strict';
+
+var assert = require('assert');
+
+var Node = require('../../lib/node/node');
+var DatabaseService = require('../../lib/service/database');
+var Factory = require('../../lib/workflow/factory');
+
+var TestConfig = require('../test-config');
+
+describe('factory', function() {
+
+    before(function() {
+        var configuration = TestConfig.create({ batch: { inlineExecution: true } });
+        this.configuration = configuration;
+        this.databaseService = new DatabaseService(
+            configuration.user,
+            configuration.db,
+            configuration.batch,
+            configuration.limits
+        );
+    });
+
+    it('basic test-source node', function(done) {
+        var TEST_SOURCE_TYPE = 'test-source';
+        var TestSource = Node.create(TEST_SOURCE_TYPE, {
+            table: Node.PARAM.STRING()
+        }, { cache: true });
+        TestSource.prototype.sql = function() {
+            return 'select * from ' + this.table;
+        };
+
+        var definition = {
+            type: TEST_SOURCE_TYPE,
+            params: {
+                table: 'airbnb_rooms'
+            }
+        };
+
+        var typeNodeMap = {};
+        typeNodeMap[TEST_SOURCE_TYPE] = TestSource;
+
+        var factory = new Factory(this.configuration.user, this.databaseService, typeNodeMap);
+        factory.create(definition, function(err, rootNode) {
+            assert.ifError(err);
+
+            assert.equal(rootNode.getType(), TEST_SOURCE_TYPE);
+            assert.equal(rootNode.sql(), 'select * from airbnb_rooms');
+            assert.ok(rootNode.getQuery().match(/^select \* from analysis_/));
+
+            return done();
+        });
+    });
+});


### PR DESCRIPTION
This allows, as per included factory integration suite, testing nodes that do not exist in the library but in the tests themselves.

This can be useful to validate Factory logic.