### PR TITLE
Allow executing an async function before the node is created

### DIFF
--- a/lib/node/node.js
+++ b/lib/node/node.js
@@ -367,6 +367,14 @@ Node.prototype.toDot = function() {
     };
 };
 
+// ----- hooks ------
+
+Node.prototype.beforeCreate = function() {};
+
+Node.prototype.beforeCreateAsync = function(databaseService, callback) {
+    return callback(null);
+};
+
 module.exports.PARAM = {
     NODE: function() {
         var args = (arguments.length === 1 ? [arguments[0]] : Array.apply(null, arguments));
@@ -449,7 +457,11 @@ module.exports.create = function createNode(type, expectedParams, options) {
         // `beforeCreate` allows to change/modify the node before it's actually created/returned
         // if it throws an error it will fail to create the node.
         if (options.beforeCreate) {
-            options.beforeCreate.bind(this)();
+            this.beforeCreate = options.beforeCreate.bind(this);
+        }
+        this.beforeCreate();
+        if (options.beforeCreateAsync) {
+            this.beforeCreateAsync = options.beforeCreateAsync.bind(this);
         }
         this.validators = Array.isArray(options.validators) ? options.validators : [];
     }

--- a/lib/node/nodes/data-observatory-multiple-measures.js
+++ b/lib/node/nodes/data-observatory-multiple-measures.js
@@ -49,6 +49,36 @@ var DataObservatoryMultipleMeasures = Node.create(TYPE, PARAMS, { cache: true, l
             throw new Error('The number of numerators=' + this.numerators.length +
                 ' does not match the number of numerator_timespans=' + this.numerator_timespans.length);
         }
+
+        this.columnTypes = this.numerators.reduce((columnTypes, numeratorId, index) => {
+            columnTypes[numeratorId] = {
+                name: this.column_names[index],
+                type: 'Numeric'
+            };
+            return columnTypes;
+        }, {});
+    },
+    beforeCreateAsync: function(databaseService, callback) {
+        const sql = columnTypesQueryTemplate({
+            source: this.source.getQuery(false),
+            obsMetaParams: this._composeObsMetaParams()
+        });
+        databaseService.run(sql, (err, result) => {
+            if (err) {
+                return callback(err);
+            }
+
+            const measures = (Array.isArray(result.rows) && result.rows[0]) || {};
+            measures.meta = measures.meta || [];
+            measures.meta.forEach(measureMetadata => {
+                if (this.columnTypes.hasOwnProperty(measureMetadata.numer_id)) {
+                    const type = (measureMetadata.numer_type.toLowerCase() === 'text') ? 'Text' : 'Numeric';
+                    this.columnTypes[measureMetadata.numer_id].type = type;
+                }
+            });
+
+            return callback(null);
+        });
     }
 });
 
@@ -79,8 +109,10 @@ DataObservatoryMultipleMeasures.prototype.sql = function() {
 
     var sql = queryTemplate({
         source: this.source.getQuery(false),
-        obsColumns: this.column_names.map(function (columnName, index) {
-            return '(data->' + index + '->>\'value\')::Numeric AS ' + columnName;
+        obsColumns: this.numerators.map((numeratorId, index) => {
+            const type = this.columnTypes[numeratorId].type;
+            const name = this.columnTypes[numeratorId].name;
+            return `(data->${index}->>'value')::${type} AS ${name}`;
         }).join(', '),
         obsMetaParams: this._composeObsMetaParams(),
         finalColumns: finalColumns
@@ -91,36 +123,46 @@ DataObservatoryMultipleMeasures.prototype.sql = function() {
     return sql;
 };
 
-var queryTemplate = Node.template([
-    'WITH _source AS (',
-    ' {{=it.source}}',
-    '),',
-    '_summary AS ( ',
-    '  SELECT',
-    '    ST_SetSRID(ST_Extent(the_geom), 4326) extent, ',
-    '    count(*)::INT numgeoms',
-    '  FROM _source',
-    '  WHERE the_geom IS NOT NULL',
-    '),',
-    '_meta AS (',
-    '  SELECT',
-    '    cdb_dataservices_client._OBS_GetMeta_exception_safe(',
-    '      extent,',
-    '      (\'{{=it.obsMetaParams}}\')::JSON, 1, 1, numgeoms',
-    '    ) as meta',
-    '  FROM _summary',
-    '),',
-    '_data AS ( ',
-    '  SELECT id AS __obs_id__, {{=it.obsColumns}}',
-    '  FROM cdb_dataservices_client._OBS_GetData_exception_safe(',
-    '    (SELECT ARRAY_AGG((the_geom, cartodb_id)::geomval) FROM _source WHERE the_geom IS NOT NULL),',
-    '    (SELECT meta FROM _meta)',
-    '  ) AS _camshaft_do_measure_analysis_data',
-    ')',
-    'SELECT {{=it.finalColumns}}',
-    'FROM _source left join _data',
-    'ON _source.cartodb_id = _data.__obs_id__'
-].join('\n'));
+const metadataCTEemplate = `
+    WITH _source AS (
+        {{=it.source}}
+    ),
+    _summary AS (
+        SELECT
+            ST_SetSRID(ST_Extent(the_geom), 4326) extent,
+            count(*)::INT numgeoms
+        FROM _source
+        WHERE the_geom IS NOT NULL
+    ),
+    _meta AS (
+        SELECT
+            cdb_dataservices_client._OBS_GetMeta_exception_safe(
+                extent, ('{{=it.obsMetaParams}}')::JSON, 1, 1, numgeoms
+            ) as meta
+        FROM _summary
+    )
+`;
+
+var queryTemplate = Node.template(`
+    ${metadataCTEemplate},
+    _data AS (
+        SELECT id AS __obs_id__, {{=it.obsColumns}}
+        FROM cdb_dataservices_client._OBS_GetData_exception_safe(
+            (SELECT ARRAY_AGG((the_geom, cartodb_id)::geomval) FROM _source WHERE the_geom IS NOT NULL),
+            (SELECT meta FROM _meta)
+        ) AS _camshaft_do_measure_analysis_data
+    )
+    SELECT {{=it.finalColumns}}
+    FROM _source left join _data
+    ON _source.cartodb_id = _data.__obs_id__
+`);
+
+
+const columnTypesQueryTemplate = Node.template(`
+    ${metadataCTEemplate}
+    SELECT meta FROM _meta
+`);
+
 
 var preCheckQueryTemplate = Node.template([
     'SELECT cdb_dataservices_client._OBS_PreCheck(\'{{=it.source}}\',',

--- a/lib/workflow/factory.js
+++ b/lib/workflow/factory.js
@@ -98,24 +98,29 @@ Factory.prototype._create = function (definition, depth, callback) {
             });
             node.addAffectedTables(affectedTables);
 
-            self.databaseService.createCacheTable(node, function(err) {
+            node.beforeCreateAsync(self.databaseService, function(err) {
                 if (err) {
                     return callback(wrapError(err));
                 }
-                self.databaseService.getColumns(node, function(err, columns) {
+                self.databaseService.createCacheTable(node, function(err) {
                     if (err) {
                         return callback(wrapError(err));
                     }
-                    node.setColumns(columns);
-                    var errors = [];
-                    var isValid = node.isValid(errors);
-                    if (!isValid) {
-                        var errorMessage = 'Validation failed: ' + errors.map(function(e) {
-                            return e.message;
-                        }).join('; ') + '.';
-                        return callback(wrapError(new Error(errorMessage)));
-                    }
-                    return callback(null, node);
+                    self.databaseService.getColumns(node, function(err, columns) {
+                        if (err) {
+                            return callback(wrapError(err));
+                        }
+                        node.setColumns(columns);
+                        var errors = [];
+                        var isValid = node.isValid(errors);
+                        if (!isValid) {
+                            var errorMessage = 'Validation failed: ' + errors.map(function(e) {
+                                return e.message;
+                            }).join('; ') + '.';
+                            return callback(wrapError(new Error(errorMessage)));
+                        }
+                        return callback(null, node);
+                    });
                 });
             });
         });

--- a/test/acceptance/data-observatory-multiple-measures.js
+++ b/test/acceptance/data-observatory-multiple-measures.js
@@ -144,4 +144,34 @@ describe('data-observatory-multiple-measures analysis', function() {
             return done();
         });
     });
+
+    it('should cast columns based on OBS_GetMeta result', function (done) {
+        const numerators = ['test.cast.text', 'es.ine.t1_1'];
+        const normalizations = ['denominated', 'denominated'];
+        const columnNames = ['text_col', 'numeric_col'];
+
+        const def = doMultipleMeasuresDefinition({
+            numerators: numerators,
+            normalizations: normalizations,
+            denominators: [null, null],
+            geom_ids: [null, null],
+            numerator_timespans: [null, null],
+            columnNames: columnNames
+        });
+
+        testHelper.createAnalyses(def, (err, analysisResult) => {
+            assert.ifError(err);
+            testHelper.executeQuery(analysisResult.getRoot().getQuery(), (err, result) => {
+                assert.ifError(err);
+
+                const textColField = result.fields.find(field => field.name === 'text_col');
+                const numericColField = result.fields.find(field => field.name === 'numeric_col');
+
+                assert.equal(textColField.type, 'string');
+                assert.equal(numericColField.type, 'number');
+
+                return done();
+            });
+        });
+    });
 });

--- a/test/fixtures/cdb_dataservices_client/obs_getmeasure.sql
+++ b/test/fixtures/cdb_dataservices_client/obs_getmeasure.sql
@@ -8,6 +8,9 @@ CREATE OR REPLACE FUNCTION cdb_dataservices_client._OBS_GetMeta_exception_safe(
 RETURNS json
 AS $$
 BEGIN
+  IF json_array_length(params) > 0 AND params->0->>'numer_id' = 'test.cast.text' THEN
+    RETURN '[{"numer_id": "test.cast.text", "numer_type": "Text"}]'::json;
+  END IF;
   RETURN '[]'::json;
 END;
 $$ LANGUAGE plpgsql;


### PR DESCRIPTION
Allow executing an async function before the node is created. This allows preparing the node using metadata from the database.

For instance, in DO analysis we will retrieve the column types for the numerators.

This closes #316.