### PR TITLE
New limit for input rows multiplied by categories

### DIFF
--- a/lib/node/limits.js
+++ b/lib/node/limits.js
@@ -7,6 +7,7 @@ var estimates = require('../limits/estimates');
 
 function limitNumberOfRows(node, context, limit, callback) {
     if (!Number.isFinite(limit.value)) {
+        context.logError('Limit for number of rows is not defined');
         return callback(null);
     }
     estimates.estimatedNumberOfRows(node, context, function(err, outputRows) {
@@ -25,6 +26,7 @@ function limitNumberOfRows(node, context, limit, callback) {
 
 function limitInputRows(node, input, context, limit, callback) {
     if (!Number.isFinite(limit.value)) {
+        context.logError('Limit for input rows is not defined');
         return callback(null);
     }
     estimates.estimatedNumberOfRows(node[input], context, function(err, numRows) {
@@ -40,12 +42,16 @@ function limitInputRows(node, input, context, limit, callback) {
     });
 }
 
-function limitInputRowsAndAvgGroupedRows(node, input, column, context, lims, callback) {
+function limitInputRowsAndAvgGroupedRows(node, input, categoriesData, context, lims, callback) {
     var limit = lims.rowsLimit;
     var groupedLimit = lims.groupedRowsLimit;
     var limitPresent = Number.isFinite(limit.value);
     var groupedLimitPresent = Number.isFinite(groupedLimit.value);
     if (!limitPresent && !groupedLimitPresent) {
+        context.logError('limitInputRowsAndAvgGroupedRows called without any passed limit');
+        return callback(null);
+    } else if (groupedLimitPresent && !_verifyCategoryData(categoriesData)) {
+        context.logError('Categories data must contain source and column name keys');
         return callback(null);
     }
 
@@ -61,6 +67,33 @@ function limitInputRowsAndAvgGroupedRows(node, input, column, context, lims, cal
         return callback(nodeError(node, messages));
     }
 
+    _limitInputRowsWithCategories(node, input, categoriesData, context, check, callback);
+}
+
+function limitInputRowsMultipliedByCategories(node, input, categoryTarget, context, limit, callback) {
+    var limitPresent = Number.isFinite(limit.value);
+    if (!limitPresent) {
+        context.logError('Limit for input rows multiplied by categories is not defined');
+        return callback(null);
+    } else if (!_verifyCategoryData(categoryTarget)) {
+        context.logError('Categories data must contain source and column name keys');
+        return callback(null);
+    }
+
+    function check(inputRows, numCategories) {
+        var maxNumberOfPossibleRows = inputRows*numCategories || 1;
+        var messages = [];
+        if (limitPresent && maxNumberOfPossibleRows > limit.value) {
+            messages.push(limit.message);
+        }
+        return callback(nodeError(node, messages));
+    }
+
+    _limitInputRowsWithCategories(node, input, categoryTarget, context, check, callback);
+
+}
+
+function _limitInputRowsWithCategories(node, input, categoryTarget, context, checkFunction, callback) {
     estimates.estimatedNumberOfRows(node[input], context, function(err, inputRows) {
         if (err) {
             context.logError(err);
@@ -68,28 +101,38 @@ function limitInputRowsAndAvgGroupedRows(node, input, column, context, lims, cal
             return callback(null);
         } else {
             var numCategories = 1;
-            if (column && groupedLimitPresent) {
+            if (categoryTarget.column) {
                 estimates.numberOfDistinctValues(
-                    node[input], context, column,
+                    node[categoryTarget.source], context, categoryTarget.column,
                     function(err, num) {
                         if (err) {
                             context.logError(err);
                         } else {
                             numCategories = num;
                         }
-                        check(inputRows, numCategories);
+                        checkFunction(inputRows, numCategories);
                     }
                 );
              }
              else {
-               check(inputRows, numCategories);
+               checkFunction(inputRows, numCategories);
              }
         }
     });
 }
 
+function _verifyCategoryData(categoryTarget) {
+    // Object could be empty but if not we check for required keys
+    if (!categoryTarget) {
+        return true;
+    } else {
+        return categoryTarget.hasOwnProperty('source') && categoryTarget.hasOwnProperty('column');
+    }
+}
+
 module.exports = {
     limitNumberOfRows: limitNumberOfRows,
     limitInputRows: limitInputRows,
-    limitInputRowsAndAvgGroupedRows: limitInputRowsAndAvgGroupedRows
+    limitInputRowsAndAvgGroupedRows: limitInputRowsAndAvgGroupedRows,
+    limitInputRowsMultipliedByCategories: limitInputRowsMultipliedByCategories
 };

--- a/lib/node/nodes/closest.js
+++ b/lib/node/nodes/closest.js
@@ -61,6 +61,20 @@ Closest.prototype.sql = function () {
 };
 
 Closest.prototype.checkLimits = function(context, callback) {
-    var limit = context.getLimit(this.getType(), 'maximumNumberOfRows', 1000000, 'too many result lines');
-    limits.limitNumberOfRows(this, context, limit, callback);
+    var maxNumberOfRows = 1000000;
+    // To avoid passing th number of responses we divide the max number of
+    // rows by the number of expected responses per row and then check by
+    // rows * categories
+    var limit = context.getLimit(
+        this.getType(), 'maximumNumberOfRows', (maxNumberOfRows/this.responses),
+        'this analysis would exceed the maximum number of results of ' + maxNumberOfRows
+    );
+    limits.limitInputRowsMultipliedByCategories(
+        this,
+        'source',
+        {source: 'target', column: this.category},
+        context,
+        limit,
+        callback
+    );
 };

--- a/lib/node/nodes/line-sequential.js
+++ b/lib/node/nodes/line-sequential.js
@@ -46,7 +46,6 @@ var routingSequentialQueryTemplate = Node.template([
 ].join('\n'));
 
 LineSequential.prototype.checkLimits = function(context, callback) {
-    var self = this;
     var rowsLimit = context.getLimit(TYPE, 'maximumNumberOfRows', 1000000, 'too many input points');
     var pointsLimit = context.getLimit(TYPE, 'maximumNumberOfPointsPerLine', 100000, 'too many points per line');
     // The limits will be applied to the estimated number of input rows and
@@ -54,7 +53,7 @@ LineSequential.prototype.checkLimits = function(context, callback) {
     limits.limitInputRowsAndAvgGroupedRows(
         this,
         'source',
-        self.category_column,
+        {source: 'source', column: this.category_column},
         context,
         { rowsLimit: rowsLimit, groupedRowsLimit: pointsLimit },
         callback


### PR DESCRIPTION
Fixes CartoDB/support#895

- Added new limit for input rows multiplied by categories (closest)
- Extract the input/grouped logic to a new function
- Category data now receives an object with source and column nave
- Added new error logs to know when a limit check is failing