### PR TITLE
Add ST_MakeValid to the trade-area-dissolved query

### DIFF
--- a/lib/node/nodes/sql/trade-area-dissolved.sql
+++ b/lib/node/nodes/sql/trade-area-dissolved.sql
@@ -22,7 +22,7 @@ _cdb_analysis_isochrones_spread AS (
 SELECT
   row_number() over() as cartodb_id,
   data_range,
-  ST_Union(the_geom) the_geom
+  ST_Union(ST_CollectionExtract(ST_MakeValid(the_geom), 3)) the_geom
 FROM
   _cdb_analysis_isochrones_spread
 GROUP BY data_range


### PR DESCRIPTION
Fixes CartoDB/support#718

Sometimes the isolines generated are invalid geometries and when
we want to dissolve them an exception is raised because ST_Union
doesn't support invalid geometries

Ok, I've done some numbers:

```
30k all invalid:  330707.630 ms
30k with 15% invalid: 120805.738 ms
30k all valid with st_makevalid: 83134.336 ms
30k all valid without makevalid: 64795.720 ms 
---------------------------------------------
5k all invalid: 50399.252 ms
5k with 25% invalid: 13325.140 ms
5k all valid with st_makevalid: 10239.036 ms
5k all valid without makevalid: 8358.520 ms
```

We're are going to introduce a 20% overhead in the dissolve query for trade-areas but I think is the only way. I tried, thanks to the @antoniocarlon's suggestion, to create a function to only apply the `ST_MakeValid` when the `ST_Union` raises an exception but is far worse in performance:

```sql
CREATE OR REPLACE FUNCTION CDB_SafeUnion(geoms geometry[])
RETURNS geometry
AS $$
DECLARE
    geom geometry;
    union_geom geometry;
BEGIN
    FOR geom IN SELECT unnest(geoms)
    LOOP
        BEGIN
            IF union_geom is NULL THEN
                SELECT ST_MakeValid(geom) INTO union_geom;
            ELSE
                SELECT ST_UNION(union_geom, geom) INTO union_geom;
            END IF;
        EXCEPTION WHEN OTHERS THEN
            SELECT ST_UNION(ST_MakeValid(union_geom), ST_MakeValid(geom)) INTO union_geom;
        END;
    END LOOP;
    RETURN union_geom;
END
$$ language plpgsql;
```

So I think the best way is to add `ST_MakeValid` to the dissolve query for the analysis
