### PR TITLE
Fix tests for PostgreSQL 10

### DIFF
--- a/test/fixtures/cdb_querytables_updated_at.sql
+++ b/test/fixtures/cdb_querytables_updated_at.sql
@@ -1,15 +1,30 @@
 CREATE OR REPLACE FUNCTION CDB_QueryTables_Updated_At(query text)
     RETURNS TABLE(dbname text, schema_name text, table_name text, updated_at timestamptz)
-AS $$
-    SELECT
-    'analysis_api_test_db'::text,
-    'public'::text,
-    CASE WHEN position('atm_machines' in query) > 0 THEN 'atm_machines'::text
-         WHEN position('multiple_tables' in query) > 0 THEN unnest(ARRAY['table_a', 'table_b']::text[])
-         ELSE 'fixture_table_name'::text
-    END,
-    CASE WHEN position('nulltime' in query) > 0
-        THEN null::timestamptz
-        ELSE '2016-07-01 11:40:05.699712+00'::timestamptz
-    END
-$$ LANGUAGE SQL;
+AS
+$BODY$
+DECLARE
+    db_name text;
+    schema_name text;
+    table_name text[];
+    updated_at timestamptz;
+BEGIN
+    db_name := 'analysis_api_test_db';
+    schema_name := 'public';
+
+    IF position('atm_machines' in query) > 0 THEN
+        table_name := ARRAY['atm_machines']::text[];
+    ELSIF position('multiple_tables' in query) > 0 THEN
+        table_name := ARRAY['table_a', 'table_b']::text[];
+    ELSE
+        table_name := ARRAY['fixture_table_name']::text[];
+    END IF;
+
+    IF position('nulltime' in query) > 0 THEN
+        updated_at := null::timestamptz;
+    ELSE
+        updated_at := '2016-07-01 11:40:05.699712+00'::timestamptz;
+    END IF;
+
+    RETURN QUERY EXECUTE 'SELECT $1, $2, unnest($3), $4' USING db_name, schema_name, table_name, updated_at;
+END
+$BODY$ LANGUAGE plpgsql;


### PR DESCRIPTION
Rewrite CDB_QueryTables_Updated_At aux function to allow execution in PostgreSQL 10. Previously it was throwing an error like this:
```
ERROR:  set-returning functions are not allowed in CASE
LINE 8: ...HEN position('multiple_tables' in query) > 0 THEN unnest(ARR...
                                                             ^
HINT:  You might be able to move the set-returning function into a LATERAL FROM item.
```