### PR TITLE
Export only one geometry

### DIFF
--- a/lib/node/nodes/sql/trade-area.sql
+++ b/lib/node/nodes/sql/trade-area.sql
@@ -13,7 +13,6 @@ _cdb_analysis_isochrones AS (
   FROM _cdb_analysis_source_points
 )
 SELECT
-  (isochrone).center,
   (isochrone).data_range,
   (isochrone).the_geom,
   {{=it.columnsQuery}}


### PR DESCRIPTION
Fixes [#12022](https://github.com/CartoDB/cartodb/issues/12022)
Exporting both center and the isoline itself caused the export to only take the center into account, resulting in a point instead of a polygon
