### PR TITLE
Using a partial index over the geometry column of the cached table

### DIFF
--- a/lib/postgresql/node-sql-adapter.js
+++ b/lib/postgresql/node-sql-adapter.js
@@ -40,6 +40,12 @@ NodeSqlAdapter.prototype.checkCacheTableQuery = function() {
     return 'SELECT CDB_CheckAnalysisQuota(\'' + this.node.getTargetTable() + '\')';
 };
 
+NodeSqlAdapter.prototype.createGeomIndexCacheTableQuery = function() {
+    return 'CREATE INDEX ON ' +
+        this.node.getTargetTable() +
+        ' USING GIST (ST_Transform(the_geom, 3857))';
+};
+
 NodeSqlAdapter.prototype.analyzeTableQuery = function() {
     return 'ANALYZE ' + this.node.getTargetTable();
 };

--- a/lib/service/database.js
+++ b/lib/service/database.js
@@ -300,6 +300,7 @@ DatabaseService.prototype.queueAnalysisOperations = function(analysis, callback)
                     query: sqlWrappedNode.annotatedNodeType() + transactionQuery([
                         sqlWrappedNode.deleteFromCacheTableQuery(),
                         sqlWrappedNode.populateCacheTableQuery(),
+                        sqlWrappedNode.createGeomIndexCacheTableQuery(),
                         sqlWrappedNode.checkCacheTableQuery(),
                         sqlWrappedNode.analyzeTableQuery()
                     ]),


### PR DESCRIPTION
In CARTO, user datasets have their geometries ready for rendering:
they are already projected and have an appropriate index.
On the opposite side, Camshaft's cached tables are not ready for
rendering: missing the adequate projection and the index.

Some numbers on this solution:
https://gist.github.com/rochoa/cf0f512cdad666f62ee5b8930cf4db94.

This is an alternative to and closes #200 and in consequence,
it also closes #201.