### PR TITLE
add the_geom_webmercator to merge node query

### DIFF
--- a/lib/node/nodes/merge.js
+++ b/lib/node/nodes/merge.js
@@ -54,10 +54,12 @@ Merge.prototype.sql = function() {
 Merge.prototype._getColumns = function() {
     var geomColumn = ((this.source_geometry === 'left_source') ? INPUT_LEFT_ALIAS : INPUT_RIGHT_ALIAS) +
         '.the_geom as the_geom';
+    var geomWmColumn = ((this.source_geometry === 'left_source') ? INPUT_LEFT_ALIAS : INPUT_RIGHT_ALIAS) +
+        '.the_geom_webmercator as the_geom_webmercator';
     var cartodbIdColumn = ((this.source_geometry === 'left_source') ? INPUT_LEFT_ALIAS : INPUT_RIGHT_ALIAS) +
         '.cartodb_id as cartodb_id';
 
-    var columns = [cartodbIdColumn, geomColumn]
+    var columns = [cartodbIdColumn, geomColumn, geomWmColumn]
         .concat(this._getLeftColumns())
         .concat(this._getRightColumns());
 


### PR DESCRIPTION
In the JOIN analysis (aka merge node), we are calculating the the_geom_webmercator on the fly. This analysis is not cached, so it is not necessary to calculate it because the source table already has the the_geom_webmercator [more info](https://github.com/CartoDB/camshaft/issues/200#issuecomment-296974271)

This PR adds the `the_geom_webmercator` to the query.

Related with https://github.com/CartoDB/Windshaft-cartodb/pull/862