### PR TITLE
Use the_geom_webmercator in merge only if available

### DIFF
--- a/lib/node/nodes/merge.js
+++ b/lib/node/nodes/merge.js
@@ -52,16 +52,15 @@ Merge.prototype.sql = function() {
 };
 
 Merge.prototype._getColumns = function() {
-    var geomColumn = ((this.source_geometry === 'left_source') ? INPUT_LEFT_ALIAS : INPUT_RIGHT_ALIAS) +
-        '.the_geom as the_geom';
-    var cartodbIdColumn = ((this.source_geometry === 'left_source') ? INPUT_LEFT_ALIAS : INPUT_RIGHT_ALIAS) +
-        '.cartodb_id as cartodb_id';
-
-    var columns = [cartodbIdColumn, geomColumn]
-        .concat(this._getLeftColumns())
-        .concat(this._getRightColumns());
-
-    return columns;
+    var columns = [];
+    var geometry_source = (this.source_geometry === 'left_source') ? INPUT_LEFT_ALIAS : INPUT_RIGHT_ALIAS;
+    columns.push(geometry_source + '.the_geom as the_geom');
+    if (this.left_source.getColumns(false).includes('the_geom_webmercator')) {
+        // if the_geom_webmercator is available, include it in the result to avoid having to ST_Tranform it for renndering
+        columns.push(geometry_source + '.the_geom_webmercator as the_geom_webmercator');
+    }
+    columns.push(geometry_source + '.cartodb_id as cartodb_id');
+    return columns.concat(this._getLeftColumns()).concat(this._getRightColumns());
 };
 
 Merge.prototype._getLeftColumns = function() {

--- a/lib/node/nodes/merge.js
+++ b/lib/node/nodes/merge.js
@@ -56,7 +56,8 @@ Merge.prototype._getColumns = function() {
     var geometry_source = (this.source_geometry === 'left_source') ? INPUT_LEFT_ALIAS : INPUT_RIGHT_ALIAS;
     columns.push(geometry_source + '.the_geom as the_geom');
     if (this.left_source.getColumns(false).includes('the_geom_webmercator')) {
-        // if the_geom_webmercator is available, include it in the result to avoid having to ST_Tranform it for renndering
+        // if the_geom_webmercator is available, include it in the result
+        //  to avoid having to ST_Transform it for rendering
         columns.push(geometry_source + '.the_geom_webmercator as the_geom_webmercator');
     }
     columns.push(geometry_source + '.cartodb_id as cartodb_id');


### PR DESCRIPTION
I intend to release this ASAP as 0.61.1 to fix a problem in 0.61.0

The problem is that in 0.61.0 we changed the merge node to use the `the_geom_webmercator` column from one of its inputs (to avoid having to calculate it later from `the_geom`). When the input is a source table we can assume that column will be present, but not in general, when inputs are other analyses.

This will require some changes in the tiler so that `the_geom_webmercator` is used (only) when available:

```diff
--- a/lib/cartodb/models/mapconfig/adapter/analysis-mapconfig-adapter.js
+++ b/lib/cartodb/models/mapconfig/adapter/analysis-mapconfig-adapter.js
@@ -184,8 +184,17 @@ var wrappedQueryTpl = dot.template([
     'FROM ({{=it._query}}) _cdb_analysis_query'
 ].join('\n'));

+// determine if a node has a usable the_geom_webmercator column;
+// otherwise to obtain it we'll need to ST_Tranform the_geom.
+function useTheGeomWebmercator(node) {
+    // * source nodes should always have an indexed the_geom_webmercator, so use it
+    // * cached nodes may have the_geom_webmercator, but they have an index on `ST_Transform(the_geom, 3857)`,
+    //   so we better use that expression instead.
+    return (node.type === 'source' || (!node.shouldCacheQuery() && node.getColumns().includes('the_geom_webmercator')));
+}
+
 function layerQuery(node) {
-    if (node.type === 'source' || node.type === 'merge') {
+    if (useTheGeomWebmercator(node)) {
         return node.getQuery();
     }
     var _columns = ['ST_Transform(the_geom, 3857) the_geom_webmercator'].concat(skipColumns(node.getColumns()));
@@ -198,7 +207,7 @@ function dataviewQuery(node, dataviewName, ownFilter) {
         applyFilters[dataviewName] = false;
     }

-    if (node.type === 'source' || node.type === 'merge') {
+    if (useTheGeomWebmercator(node)) {
         return node.getQuery(applyFilters);
     }
     var _columns = ['ST_Transform(the_geom, 3857) the_geom_webmercator'].concat(skipColumns(node.getColumns()));
diff --git a/package.json b/package.json
index a0d2ed1..e2d295f 100644
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   ],
   "dependencies": {
     "body-parser": "^1.18.2",
-    "camshaft": "0.61.0",
+    "camshaft": "0.61.1",
     "cartodb-psql": "0.10.2",
     "cartodb-query-tables": "0.3.0",
     "cartodb-redis": "0.14.0",
```
