### PR TITLE
Change line-sequential legnth units to meters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.61.2
 Released 2017-mm-dd
+  - Fix: compute line-sequential length properly as geodesic distance in meters
 
 ## 0.61.1
 Released 2017-02-06

--- a/lib/node/nodes/line-sequential.js
+++ b/lib/node/nodes/line-sequential.js
@@ -33,7 +33,7 @@ var routingSequentialQueryTemplate = Node.template([
     'SELECT',
     '  row_number() over() AS cartodb_id,',
     '  *,',
-    '  ST_Length(the_geom) as length',
+    '  ST_Length(the_geom::geography) as length',
     'FROM (',
     '  SELECT',
     '    {{? it.category_column }}{{=it.category_column}} as category,{{?}}',


### PR DESCRIPTION
We had this `ST_Length` operating on WGS84 degrees; the rest already do the proper thing operating on geography and returning a meaningful result in meters