### PR TITLE
Apply ST_Subdivide to intersection queries

### DIFF
--- a/lib/node/nodes/intersection.js
+++ b/lib/node/nodes/intersection.js
@@ -27,7 +27,8 @@ Intersection.prototype.sql = function() {
     var sql = queryTemplate({
         sourceQuery: this.source.getQuery(),
         targetQuery: this.target.getQuery(),
-        columns: ['_cdb_analysis_target.*'].concat(prefixedSourceColumns).join(',')
+        columns: ['_cdb_analysis_target.*'].concat(prefixedSourceColumns).join(','),
+        sourceColumns: this.source_columns.join(',')
     });
 
     debug(sql);
@@ -37,6 +38,7 @@ Intersection.prototype.sql = function() {
 
 var queryTemplate = Node.template([
     'SELECT {{=it.columns}}',
-    'FROM ({{=it.sourceQuery}}) _cdb_analysis_source, ({{=it.targetQuery}}) _cdb_analysis_target',
-    'WHERE ST_Intersects(_cdb_analysis_source.the_geom, _cdb_analysis_target.the_geom)'
+    'FROM (SELECT ST_Subdivide(the_geom) AS the_geom, {{=it.sourceColumns}} FROM ({{=it.sourceQuery}}) _subq) _cdb_analysis_source',
+    'JOIN ({{=it.targetQuery}}) _cdb_analysis_target',
+    'ON ST_Intersects(_cdb_analysis_source.the_geom, _cdb_analysis_target.the_geom)'
 ].join('\n'));


### PR DESCRIPTION
This should make p-i-p joins run faster, in most cases (large point collections, larger polygons). Even for cases with smaller polygons, the small ones won't get subdivided, so not really any extra overhead. Only potential slowdown would be cases with few points on the target side. Code utterly untested as I don't have a real dev env.