### PR TITLE
TradeArea: Make sure the output 'cartodb_id' is unique

### DIFF
--- a/lib/node/nodes/sql/trade-area.sql
+++ b/lib/node/nodes/sql/trade-area.sql
@@ -9,13 +9,16 @@ _cdb_analysis_isochrones AS (
       '{{=it.kind}}',
       ARRAY[{{=it.isolines}}]::integer[]
     ) as isochrone,
+    _cdb_analysis_source_points.cartodb_id as source_cartodb_id,
     {{=it.columnsQuery}}
   FROM _cdb_analysis_source_points
 )
 SELECT
+  row_number() over() as cartodb_id,
   (isochrone).center,
   (isochrone).data_range,
   (isochrone).the_geom,
+  source_cartodb_id,
   {{=it.columnsQuery}}
 FROM _cdb_analysis_isochrones
 ORDER BY (isochrone).data_range DESC

--- a/lib/node/nodes/trade-area.js
+++ b/lib/node/nodes/trade-area.js
@@ -23,7 +23,7 @@ TradeArea.prototype.sql = function() {
 
     return template({
         pointsQuery: this.source.getQuery(),
-        columnsQuery: this.source.getColumns(true).join(', '),
+        columnsQuery: this.source.getColumns(true).filter(columnName => columnName !== 'cartodb_id').join(', '),
         kind: this.kind,
         isolines: buildRange(this.time, this.isolines).join(', ')
     });

--- a/test/acceptance/trade-area.js
+++ b/test/acceptance/trade-area.js
@@ -46,6 +46,17 @@ describe('trade-area analysis', function() {
                 });
             });
         });
+
+        it('should return unique cartodb_ids', function (done) {
+            testHelper.getResult(tradeAreaDefinition, function(err, result) {
+                assert.ifError(err);
+                result.sort(function(a,b) {
+                    assert.ok(a.cartodb_id !== b.cartodb_id);
+                    return a.cartodb_id < b.cartodb_id;
+                });
+                return done();
+            });
+        });
     });
 
     describe('trade area analysis dissolved', function () {
@@ -69,8 +80,7 @@ describe('trade-area analysis', function() {
                 testHelper.getRows(rootNode.getQuery(), function(err, rows) {
                     assert.ifError(err);
                     rows.forEach(function(row) {
-                        // FIXME: should return cartodb_id
-                        // assert.ok(typeof row.cartodb_id === 'number');
+                        assert.ok(typeof row.cartodb_id === 'number');
                         assert.ok(typeof row.the_geom === 'string');
                         assert.ok(typeof row.data_range === 'number');
                     });

--- a/test/acceptance/trade-area.js
+++ b/test/acceptance/trade-area.js
@@ -50,10 +50,9 @@ describe('trade-area analysis', function() {
         it('should return unique cartodb_ids', function (done) {
             testHelper.getResult(tradeAreaDefinition, function(err, result) {
                 assert.ifError(err);
-                result.sort(function(a,b) {
-                    assert.ok(a.cartodb_id !== b.cartodb_id);
-                    return a.cartodb_id < b.cartodb_id;
-                });
+                const uniqueIds = [...new Set(result.map(r => r.cartodb_id))];
+                assert.equal(uniqueIds.length, result.length);
+
                 return done();
             });
         });

--- a/test/fixtures/cdb_dataservices_client/cdb_isochrone.sql
+++ b/test/fixtures/cdb_dataservices_client/cdb_isochrone.sql
@@ -1,4 +1,11 @@
-CREATE OR REPLACE FUNCTION cdb_dataservices_client._cdb_isochrone_exception_safe(center GEOMETRY, kind TEXT, range INTEGER[], OUT center geometry, OUT data_range integer, OUT the_geom geometry)
+CREATE TYPE cdb_dataservices_client.isoline AS (
+    center geometry(Geometry,4326),
+    data_range integer,
+    the_geom geometry(Multipolygon,4326)
+);
+
+CREATE OR REPLACE FUNCTION cdb_dataservices_client._cdb_isochrone_exception_safe(source geometry(Geometry, 4326), mode text, range integer[], options text[] DEFAULT ARRAY[]::text[])
+RETURNS SETOF cdb_dataservices_client.isoline
 AS $$
   SELECT
     $1 center,


### PR DESCRIPTION
Related to https://github.com/CartoDB/support/issues/1332

Currently the AOI (non dissolved) analysis returns multiple rows with the same `cartodb_id` (one per isoline) which is troublesome when you do other analyses on top of it. This PR:
* Recalculates cartodb_id to be unique (as with the dissolved analysis).
* Adds a `source_cartodb_id` column in case we want to go back to the original table.
* Changes the `cdb_dataservices_client._cdb_isochrone_exception_safe` fixture to have the same signature as the original function, most importantly returning a set so the issue could be reproduced.