### PR TITLE
Merge: Make sure the output 'cartodb_id' is unique

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Changelog
+## 0.61.4
+Released 2017-03-13
+  - Merge: Make sure the output 'cartodb_id' is unique
 
 ## 0.61.3
 Released 2017-03-12
-  - TradeArea: Make sure the output 'cartodb_id' is unique 
+  - TradeArea: Make sure the output 'cartodb_id' is unique
 
 ## 0.61.2
 Released 2017-02-08

--- a/lib/node/nodes/merge.js
+++ b/lib/node/nodes/merge.js
@@ -54,10 +54,8 @@ Merge.prototype.sql = function() {
 Merge.prototype._getColumns = function() {
     var geomColumn = ((this.source_geometry === 'left_source') ? INPUT_LEFT_ALIAS : INPUT_RIGHT_ALIAS) +
         '.the_geom as the_geom';
-    var cartodbIdColumn = ((this.source_geometry === 'left_source') ? INPUT_LEFT_ALIAS : INPUT_RIGHT_ALIAS) +
-        '.cartodb_id as cartodb_id';
 
-    var columns = [cartodbIdColumn, geomColumn]
+    var columns = [geomColumn]
         .concat(this._getLeftColumns())
         .concat(this._getRightColumns());
 
@@ -69,10 +67,6 @@ Merge.prototype._getLeftColumns = function() {
         this.left_source.getColumns(true) :
         this.left_source_columns;
 
-    if (this.source_geometry === 'left_source') {
-        leftColumns = skipCartoDBId(leftColumns);
-    }
-
     leftColumns = setAliasTo(leftColumns, INPUT_LEFT_ALIAS, 'left');
 
     return leftColumns;
@@ -81,29 +75,21 @@ Merge.prototype._getLeftColumns = function() {
 Merge.prototype._getRightColumns = function () {
     var rightColumns = this.right_source_columns;
 
-    if (this.source_geometry === 'right_source') {
-        rightColumns = skipCartoDBId(rightColumns);
-    }
-
     rightColumns = setAliasTo(rightColumns, INPUT_RIGHT_ALIAS, 'right');
 
     return rightColumns;
 };
 
 var queryTemplate = dot.template([
-    'SELECT {{=it.columns}}',
+    'SELECT ',
+    '  row_number() over() as cartodb_id,',
+    '  {{=it.columns}}',
     'FROM',
     '  ({{=it.input_left}}) AS {{=it.input_left_alias}}',
     '  {{=it.join_operation}}',
     '  ({{=it.input_right}}) AS {{=it.input_right_alias}}',
     'ON {{=it.input_left_column_join_on}} = {{=it.input_right_column_join_on}}'
 ].join('\n'));
-
-function skipCartoDBId(columns) {
-    return columns.filter(function (column) {
-        return column !== 'cartodb_id';
-    });
-}
 
 function setAliasTo(columns, alias, as) {
     return columns.map(function (column) {

--- a/test/integration/nodes.js
+++ b/test/integration/nodes.js
@@ -9,6 +9,7 @@ var QueryParser = require('../../lib/postgresql/query-parser');
 var DatabaseService = require('../../lib/service/database');
 
 var testConfig = require('../test-config');
+var testHelper = require('../helper');
 
 describe('nodes', function() {
 
@@ -519,5 +520,36 @@ describe('nodes', function() {
                 done();
             });
         });
+
+        it('merge should return unique cartodb_ids', function(done) {
+            var merge = {
+                type: 'merge',
+                params: {
+                    left_source: SOURCE_ATM_MACHINES_DEF,
+                    right_source: SOURCE_ATM_MACHINES_DEF,
+                    left_source_column: 'bank',
+                    right_source_column: 'bank',
+                    left_source_columns: ['the_geom', 'indoor', 'cartodb_id'],
+                    right_source_columns: ['the_geom', 'indoor', 'cartodb_id']
+                }
+            };
+
+            testHelper.createAnalyses(merge, function(err, results) {
+                assert.ifError(err);
+
+                var rootNode = results.getRoot();
+
+                testHelper.getRows(rootNode.getQuery(), function(err, rows) {
+                    assert.ifError(err);
+                    const uniqueIds = [...new Set(rows.map(r => r.cartodb_id))];
+                    assert.equal(uniqueIds.length, rows.length);
+
+                    return done();
+                });
+            });
+
+        });
+
+
     });
 });


### PR DESCRIPTION
Related to https://github.com/CartoDB/support/issues/1298

Currently the merge analysis can return duplicated cartodb_id's if any row from the `source_geometry` table matches with more than one row from the other table. To avoid the issue I've kept the original cartodb_id intact as `left_cartodb_id` or `right_cartodb_id` and regenerate it with `row_number() over() as cartodb_id`.