### PR TITLE
Chained analyses (Merge and TradeArea)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Released 2017-03-13
   - Merge: Make sure the output 'cartodb_id' is unique
   - Merge: Allow chained merge analyses
+  - TradeArea: Allow chained analyses
 
 ## 0.61.3
 Released 2017-03-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## 0.61.4
 Released 2017-03-13
   - Merge: Make sure the output 'cartodb_id' is unique
+  - Merge: Allow chained merge analyses
 
 ## 0.61.3
 Released 2017-03-12

--- a/lib/node/node.js
+++ b/lib/node/node.js
@@ -7,7 +7,7 @@ var templateLoader = require('../util/template-loader');
 var dot = require('dot');
 dot.templateSettings.strip = false;
 
-var util_id = require('../util/id');
+var utilId = require('../util/id');
 var QueryBuilder = require('../filter/query-builder');
 var Validator = require('./validator');
 module.exports.Validator = Validator;
@@ -109,7 +109,7 @@ Node.prototype.id = function(skipFilters) {
         return json;
     }.bind(this), {});
 
-    return util_id.id({
+    return utilId.id({
         // Internal version.
         // Bump this for backwards incompatible changes.
         __version__: 1,
@@ -163,7 +163,7 @@ Node.prototype.getType = function() {
 
 Node.prototype.getTypeSignature = function() {
     if (this.typeSignature === null) {
-        this.typeSignature = util_id.id(this.getType()).substring(0, 10);
+        this.typeSignature = utilId.id(this.getType()).substring(0, 10);
     }
     return this.typeSignature;
 };

--- a/lib/node/node.js
+++ b/lib/node/node.js
@@ -7,7 +7,7 @@ var templateLoader = require('../util/template-loader');
 var dot = require('dot');
 dot.templateSettings.strip = false;
 
-var id = require('../util/id');
+var util_id = require('../util/id');
 var QueryBuilder = require('../filter/query-builder');
 var Validator = require('./validator');
 module.exports.Validator = Validator;
@@ -109,7 +109,7 @@ Node.prototype.id = function(skipFilters) {
         return json;
     }.bind(this), {});
 
-    return id({
+    return util_id.id({
         // Internal version.
         // Bump this for backwards incompatible changes.
         __version__: 1,
@@ -163,7 +163,7 @@ Node.prototype.getType = function() {
 
 Node.prototype.getTypeSignature = function() {
     if (this.typeSignature === null) {
-        this.typeSignature = id(this.getType()).substring(0, 10);
+        this.typeSignature = util_id.id(this.getType()).substring(0, 10);
     }
     return this.typeSignature;
 };

--- a/lib/node/nodes/merge.js
+++ b/lib/node/nodes/merge.js
@@ -23,9 +23,6 @@ var Merge = Node.create(TYPE, PARAMS);
 
 module.exports = Merge;
 
-var INPUT_LEFT_ALIAS = '_cdb_analysis_left_source';
-var INPUT_RIGHT_ALIAS = '_cdb_analysis_right_source';
-
 var JOIN_OPERATIONS = {
     inner: 'INNER JOIN',
     left: 'LEFT JOIN',
@@ -33,17 +30,23 @@ var JOIN_OPERATIONS = {
 };
 
 Merge.prototype.sql = function() {
-    var columns = this._getColumns();
+    var hrTime = process.hrtime();
+    var time_ns = hrTime[0] * 1000000 + Math.round(hrTime[1] / 1000);
+
+    var left_alias = '_cdb_analysis_left_source' + time_ns.toString();
+    var right_alias = '_cdb_analysis_right_source' + time_ns.toString();
+
+    var columns = this._getColumns(left_alias, right_alias);
 
     var sql = queryTemplate({
         columns: columns.join(', '),
-        input_left_alias: INPUT_LEFT_ALIAS,
-        input_right_alias: INPUT_RIGHT_ALIAS,
+        input_left_alias: left_alias,
+        input_right_alias: right_alias,
         input_left: this.left_source.getQuery(),
         join_operation: JOIN_OPERATIONS[this.join_operator],
         input_right: this.right_source.getQuery(),
-        input_left_column_join_on: INPUT_LEFT_ALIAS + '.' + this.left_source_column,
-        input_right_column_join_on: INPUT_RIGHT_ALIAS + '.' + this.right_source_column
+        input_left_column_join_on: left_alias + '.' + this.left_source_column,
+        input_right_column_join_on: right_alias + '.' + this.right_source_column
     });
 
     debug(sql);
@@ -51,31 +54,42 @@ Merge.prototype.sql = function() {
     return sql;
 };
 
-Merge.prototype._getColumns = function() {
-    var geomColumn = ((this.source_geometry === 'left_source') ? INPUT_LEFT_ALIAS : INPUT_RIGHT_ALIAS) +
+Merge.prototype._getColumns = function(left_alias, right_alias) {
+    var geomColumn = ((this.source_geometry === 'left_source') ? left_alias : right_alias) +
         '.the_geom as the_geom';
 
     var columns = [geomColumn]
-        .concat(this._getLeftColumns())
-        .concat(this._getRightColumns());
+        .concat(this._getLeftColumns(left_alias))
+        .concat(this._getRightColumns(right_alias));
 
     return columns;
 };
 
-Merge.prototype._getLeftColumns = function() {
+Merge.prototype._getLeftColumns = function(left_alias) {
     var leftColumns = (this.left_source_columns === null) ?
         this.left_source.getColumns(true) :
         this.left_source_columns;
 
-    leftColumns = setAliasTo(leftColumns, INPUT_LEFT_ALIAS, 'left');
+    if (this.source_geometry === 'left_source') {
+        leftColumns = leftColumns.filter(function (column) {
+            return (/^.*the_geom$/.test(column) === false);
+        });
+    };
 
+    leftColumns = setAliasTo(leftColumns, left_alias, 'left');
     return leftColumns;
 };
 
-Merge.prototype._getRightColumns = function () {
+Merge.prototype._getRightColumns = function (right_alias) {
     var rightColumns = this.right_source_columns;
 
-    rightColumns = setAliasTo(rightColumns, INPUT_RIGHT_ALIAS, 'right');
+    if (this.source_geometry === 'right_source') {
+        rightColumns = rightColumns.filter(function (column) {
+            return (/^.*the_geom$/.test(column) === false);
+        });
+    }
+
+    rightColumns = setAliasTo(rightColumns, right_alias, 'right');
 
     return rightColumns;
 };
@@ -97,7 +111,7 @@ function setAliasTo(columns, alias, as) {
 
         if (as === 'left') {
             // only set alias to cartodb_id column
-            if (column === 'cartodb_id') {
+            if (/^.*cartodb_id$/.test(column)) {
                 qualifiedColumnName += ' as ' + as + '_' + column;
             }
         } else if (as) {

--- a/lib/node/nodes/merge.js
+++ b/lib/node/nodes/merge.js
@@ -73,7 +73,7 @@ Merge.prototype._getLeftColumns = function(left_alias) {
         leftColumns = leftColumns.filter(function (column) {
             return (/^.*the_geom$/.test(column) === false);
         });
-    };
+    }
 
     leftColumns = setAliasTo(leftColumns, left_alias, 'left');
     return leftColumns;

--- a/lib/node/nodes/merge.js
+++ b/lib/node/nodes/merge.js
@@ -4,7 +4,7 @@ var dot = require('dot');
 dot.templateSettings.strip = false;
 
 var debug = require('../../util/debug')('analysis:merge');
-
+var util_id = require('../../util/id');
 var Node = require('../node');
 
 var TYPE = 'merge';
@@ -30,11 +30,10 @@ var JOIN_OPERATIONS = {
 };
 
 Merge.prototype.sql = function() {
-    var hrTime = process.hrtime();
-    var time_ns = hrTime[0] * 1000000 + Math.round(hrTime[1] / 1000);
+    var buster = util_id.buster();
 
-    var left_alias = '_cdb_analysis_left_source' + time_ns.toString();
-    var right_alias = '_cdb_analysis_right_source' + time_ns.toString();
+    var left_alias = '_cdb_analysis_left_source' + buster;
+    var right_alias = '_cdb_analysis_right_source' + buster;
 
     var columns = this._getColumns(left_alias, right_alias);
 

--- a/lib/node/nodes/merge.js
+++ b/lib/node/nodes/merge.js
@@ -4,7 +4,7 @@ var dot = require('dot');
 dot.templateSettings.strip = false;
 
 var debug = require('../../util/debug')('analysis:merge');
-var util_id = require('../../util/id');
+var utilId = require('../../util/id');
 var Node = require('../node');
 
 var TYPE = 'merge';
@@ -30,7 +30,7 @@ var JOIN_OPERATIONS = {
 };
 
 Merge.prototype.sql = function() {
-    var buster = util_id.buster();
+    var buster = utilId.buster();
 
     var left_alias = '_cdb_analysis_left_source' + buster;
     var right_alias = '_cdb_analysis_right_source' + buster;
@@ -64,15 +64,17 @@ Merge.prototype._getColumns = function(left_alias, right_alias) {
     return columns;
 };
 
+function isNotAGeometryColumn(column) {
+    return !(column.endsWith('the_geom'));
+}
+
 Merge.prototype._getLeftColumns = function(left_alias) {
     var leftColumns = (this.left_source_columns === null) ?
         this.left_source.getColumns(true) :
         this.left_source_columns;
 
     if (this.source_geometry === 'left_source') {
-        leftColumns = leftColumns.filter(function (column) {
-            return (/^.*the_geom$/.test(column) === false);
-        });
+        leftColumns = leftColumns.filter(isNotAGeometryColumn);
     }
 
     leftColumns = setAliasTo(leftColumns, left_alias, 'left');
@@ -83,9 +85,7 @@ Merge.prototype._getRightColumns = function (right_alias) {
     var rightColumns = this.right_source_columns;
 
     if (this.source_geometry === 'right_source') {
-        rightColumns = rightColumns.filter(function (column) {
-            return (/^.*the_geom$/.test(column) === false);
-        });
+        rightColumns = rightColumns.filter(isNotAGeometryColumn);
     }
 
     rightColumns = setAliasTo(rightColumns, right_alias, 'right');
@@ -110,7 +110,7 @@ function setAliasTo(columns, alias, as) {
 
         if (as === 'left') {
             // only set alias to cartodb_id column
-            if (/^.*cartodb_id$/.test(column)) {
+            if (column.endsWith('cartodb_id')) {
                 qualifiedColumnName += ' as ' + as + '_' + column;
             }
         } else if (as) {

--- a/lib/node/nodes/trade-area.js
+++ b/lib/node/nodes/trade-area.js
@@ -18,7 +18,7 @@ var TradeArea = Node.create(TYPE, PARAMS, { cache: true, version: 3, tags: ['io4
 
 module.exports = TradeArea;
 
-const DROPCOLUMN = {
+const DROP_COLUMN = {
     'cartodb_id' : true,
     'source_cartodb_id' : true,
     'center' : true,
@@ -31,7 +31,7 @@ TradeArea.prototype.sql = function() {
 
     return template({
         pointsQuery: this.source.getQuery(),
-        columnsQuery: this.source.getColumns(true).filter(columnName => !(DROPCOLUMN[columnName])).join(', '),
+        columnsQuery: this.source.getColumns(true).filter(columnName => !(DROP_COLUMN[columnName])).join(', '),
         kind: this.kind,
         isolines: buildRange(this.time, this.isolines).join(', ')
     });

--- a/lib/node/nodes/trade-area.js
+++ b/lib/node/nodes/trade-area.js
@@ -19,11 +19,11 @@ var TradeArea = Node.create(TYPE, PARAMS, { cache: true, version: 3, tags: ['io4
 module.exports = TradeArea;
 
 const DROPCOLUMN = {
-    "cartodb_id" : true,
-    "source_cartodb_id" : true,
-    "center" : true,
-    "data_range" : true,
-    "the_geom" : true
+    'cartodb_id' : true,
+    'source_cartodb_id' : true,
+    'center' : true,
+    'data_range' : true,
+    'the_geom' : true
 };
 
 TradeArea.prototype.sql = function() {

--- a/lib/node/nodes/trade-area.js
+++ b/lib/node/nodes/trade-area.js
@@ -18,12 +18,20 @@ var TradeArea = Node.create(TYPE, PARAMS, { cache: true, version: 3, tags: ['io4
 
 module.exports = TradeArea;
 
+const DROPCOLUMN = {
+    "cartodb_id" : true,
+    "source_cartodb_id" : true,
+    "center" : true,
+    "data_range" : true,
+    "the_geom" : true
+};
+
 TradeArea.prototype.sql = function() {
     var template = this.dissolved ? tradeAreasDissolvedQueryTemplate : tradeAreasQueryTemplate;
 
     return template({
         pointsQuery: this.source.getQuery(),
-        columnsQuery: this.source.getColumns(true).filter(columnName => columnName !== 'cartodb_id').join(', '),
+        columnsQuery: this.source.getColumns(true).filter(columnName => !(DROPCOLUMN[columnName])).join(', '),
         kind: this.kind,
         isolines: buildRange(this.time, this.isolines).join(', ')
     });

--- a/lib/util/id.js
+++ b/lib/util/id.js
@@ -2,8 +2,11 @@
 
 var crypto = require('crypto');
 
-function id(content) {
+module.exports.id = function(content) {
     return crypto.createHash('sha1').update(JSON.stringify(content)).digest('hex');
-}
+};
 
-module.exports = id;
+module.exports.buster = function() {
+    var hrTime = process.hrtime();
+    return hrTime[0] * 1000000 + Math.round(hrTime[1] / 1000);
+};

--- a/test/acceptance/trade-area.js
+++ b/test/acceptance/trade-area.js
@@ -56,6 +56,39 @@ describe('trade-area analysis', function() {
                 return done();
             });
         });
+
+        it('should allow chained analyses', function (done) {
+            var tradeAreaDefinition2 = {
+                type: 'trade-area',
+                params: {
+                    source: tradeAreaDefinition,
+                    kind: KIND,
+                    time: TIME,
+                    isolines: ISOLINES,
+                    dissolved: false
+                }
+            };
+
+            var tradeAreaDefinition3 = {
+                type: 'trade-area',
+                params: {
+                    source: tradeAreaDefinition2,
+                    kind: KIND,
+                    time: TIME,
+                    isolines: ISOLINES,
+                    dissolved: false
+                }
+            };
+
+            testHelper.getResult(tradeAreaDefinition3, function(err, result) {
+                assert.ifError(err);
+                const uniqueIds = [...new Set(result.map(r => r.cartodb_id))];
+                assert.equal(uniqueIds.length, result.length);
+
+                return done();
+            });
+        });
+
     });
 
     describe('trade area analysis dissolved', function () {
@@ -88,5 +121,38 @@ describe('trade-area analysis', function() {
                 });
             });
         });
+
+        it('should allow chained analyses', function (done) {
+            var tradeAreaDefinition2 = {
+                type: 'trade-area',
+                params: {
+                    source: tradeAreaDefinition,
+                    kind: KIND,
+                    time: TIME,
+                    isolines: ISOLINES,
+                    dissolved: true
+                }
+            };
+
+            var tradeAreaDefinition3 = {
+                type: 'trade-area',
+                params: {
+                    source: tradeAreaDefinition2,
+                    kind: KIND,
+                    time: TIME,
+                    isolines: ISOLINES,
+                    dissolved: true
+                }
+            };
+
+            testHelper.getResult(tradeAreaDefinition3, function(err, result) {
+                assert.ifError(err);
+                const uniqueIds = [...new Set(result.map(r => r.cartodb_id))];
+                assert.equal(uniqueIds.length, result.length);
+
+                return done();
+            });
+        });
+
     });
 });

--- a/test/integration/nodes.js
+++ b/test/integration/nodes.js
@@ -550,6 +550,58 @@ describe('nodes', function() {
 
         });
 
+        it('merge should allow chained merges', function(done) {
+            var merge = {
+                type: 'merge',
+                params: {
+                    left_source: SOURCE_ATM_MACHINES_DEF,
+                    right_source: SOURCE_ATM_MACHINES_DEF,
+                    left_source_column: 'bank',
+                    right_source_column: 'bank',
+                    left_source_columns: ['the_geom', 'indoor', 'cartodb_id', 'bank'],
+                    right_source_columns: ['the_geom', 'indoor', 'cartodb_id']
+                }
+            };
+
+            var merge2 = {
+                type: 'merge',
+                params: {
+                    left_source: merge,
+                    right_source: SOURCE_ATM_MACHINES_DEF,
+                    left_source_column: 'bank',
+                    right_source_column: 'bank',
+                    left_source_columns: ['the_geom', 'indoor', 'cartodb_id', 'bank'],
+                    right_source_columns: ['the_geom', 'indoor', 'cartodb_id']
+                }
+            };
+
+            var merge3 = {
+                type: 'merge',
+                params: {
+                    left_source: merge2,
+                    right_source: SOURCE_ATM_MACHINES_DEF,
+                    left_source_column: 'bank',
+                    right_source_column: 'bank',
+                    left_source_columns: ['the_geom', 'indoor', 'cartodb_id', 'bank'],
+                    right_source_columns: ['the_geom', 'indoor', 'cartodb_id']
+                }
+            };
+
+            testHelper.createAnalyses(merge3, function(err, results) {
+                assert.ifError(err);
+
+                var rootNode = results.getRoot();
+
+                testHelper.getRows(rootNode.getQuery(), function(err, rows) {
+                    assert.ifError(err);
+                    const uniqueIds = [...new Set(rows.map(r => r.cartodb_id))];
+                    assert.equal(uniqueIds.length, rows.length);
+
+                    return done();
+                });
+            });
+        });
+
 
     });
 });


### PR DESCRIPTION
While testing the changes I did for https://github.com/CartoDB/support/issues/1298 (avoiding repeated cartodb_id's from analyses) I've faced several times the issue of not being able to create chained analyses from the 2 I was testing (trade area and merge), so here are the fixes for both.

Please let me know if anything needs explanation and I'll try to make it clearer.

I think this also:
* Closes https://github.com/CartoDB/camshaft/issues/268
* References https://github.com/CartoDB/camshaft/issues/330 (Other analyses should still be reviewed)
