### PR TITLE
Update request to 2.85.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Changelog
 ## 0.61.4
-Released 2017-03-13
+Released 2017-03-14
   - Merge: Make sure the output 'cartodb_id' is unique
   - Merge: Allow chained merge analyses
   - TradeArea: Allow chained analyses
+  - Update request to 2.85.0
 
 ## 0.61.3
 Released 2017-03-12

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "camshaft",
-  "version": "0.61.3",
+  "version": "0.61.4",
   "description": "Analysis library to create data views from queries",
   "main": "./lib/analysis.js",
   "scripts": {
@@ -28,7 +28,7 @@
     "cartodb-psql": "^0.10.1",
     "debug": "^3.1.0",
     "dot": "^1.0.3",
-    "request": "^2.69.0"
+    "request": "2.85.0"
   },
   "devDependencies": {
     "cartodb-redis": "^0.13.0",


### PR DESCRIPTION
This is to match Windshaft and Windshaft-cartodb releases and to avoid 2.84.0 which is broken for node6.