### PR TITLE
Merge: Avoid issues when mixing left and right joins

### DIFF
--- a/lib/node/nodes/merge.js
+++ b/lib/node/nodes/merge.js
@@ -109,8 +109,8 @@ function setAliasTo(columns, alias, as) {
         var qualifiedColumnName = alias + '.' + column;
 
         if (as === 'left') {
-            // only set alias to cartodb_id column
-            if (column.endsWith('cartodb_id')) {
+            // Set alias to cartodb_id and any column that starts with 'right_'
+            if (column.endsWith('cartodb_id') || column.startsWith('right_')) {
                 qualifiedColumnName += ' as ' + as + '_' + column;
             }
         } else if (as) {

--- a/test/integration/nodes.js
+++ b/test/integration/nodes.js
@@ -558,7 +558,6 @@ describe('nodes', function() {
                     right_source: SOURCE_ATM_MACHINES_DEF,
                     left_source_column: 'bank',
                     right_source_column: 'bank',
-                    left_source_columns: ['the_geom', 'indoor', 'cartodb_id', 'bank'],
                     right_source_columns: ['the_geom', 'indoor', 'cartodb_id']
                 }
             };
@@ -568,9 +567,9 @@ describe('nodes', function() {
                 params: {
                     left_source: merge,
                     right_source: SOURCE_ATM_MACHINES_DEF,
+                    join_operator: 'left',
                     left_source_column: 'bank',
                     right_source_column: 'bank',
-                    left_source_columns: ['the_geom', 'indoor', 'cartodb_id', 'bank'],
                     right_source_columns: ['the_geom', 'indoor', 'cartodb_id']
                 }
             };
@@ -580,14 +579,26 @@ describe('nodes', function() {
                 params: {
                     left_source: merge2,
                     right_source: SOURCE_ATM_MACHINES_DEF,
+                    join_operator: 'right',
                     left_source_column: 'bank',
                     right_source_column: 'bank',
-                    left_source_columns: ['the_geom', 'indoor', 'cartodb_id', 'bank'],
                     right_source_columns: ['the_geom', 'indoor', 'cartodb_id']
                 }
             };
 
-            testHelper.createAnalyses(merge3, function(err, results) {
+            var merge4 = {
+                type: 'merge',
+                params: {
+                    left_source: merge2,
+                    right_source: merge3,
+                    join_operator: 'inner',
+                    left_source_column: 'bank',
+                    right_source_column: 'bank',
+                    right_source_columns: ['the_geom', 'indoor', 'cartodb_id']
+                }
+            };
+
+            testHelper.createAnalyses(merge4, function(err, results) {
                 assert.ifError(err);
 
                 var rootNode = results.getRoot();


### PR DESCRIPTION
Addendum to https://github.com/CartoDB/camshaft/pull/355

If you mix right and left joins you could have a column named `right_X` in the left node that would conflict with `X` from the right node.