### PR TITLE
Revert join issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 ## 0.61.7
 Released 2018-03-16:
   - Revert: `Merge: Update version` (0.61.6)
-
+  - Revert: `Merge: Avoid issues when mixing left and right joins` (0.61.4)
 
 ## 0.61.6
 Released 2018-03-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## 0.61.7
+Released 2018-03-16:
+  - Revert: `Merge: Update version` (0.61.6)
+
+
 ## 0.61.6
 Released 2018-03-15
   - Merge: Update version

--- a/lib/node/nodes/merge.js
+++ b/lib/node/nodes/merge.js
@@ -19,7 +19,7 @@ var PARAMS = {
     right_source_columns: Node.PARAM.NULLABLE(Node.PARAM.ARRAY(Node.PARAM.STRING()), [])
 };
 
-var Merge = Node.create(TYPE, PARAMS, {version: 1});
+var Merge = Node.create(TYPE, PARAMS);
 
 module.exports = Merge;
 

--- a/lib/node/nodes/merge.js
+++ b/lib/node/nodes/merge.js
@@ -109,8 +109,8 @@ function setAliasTo(columns, alias, as) {
         var qualifiedColumnName = alias + '.' + column;
 
         if (as === 'left') {
-            // Set alias to cartodb_id and any column that starts with 'right_'
-            if (column.endsWith('cartodb_id') || column.startsWith('right_')) {
+            // only set alias to cartodb_id column
+            if (column.endsWith('cartodb_id')) {
                 qualifiedColumnName += ' as ' + as + '_' + column;
             }
         } else if (as) {

--- a/test/integration/nodes.js
+++ b/test/integration/nodes.js
@@ -558,6 +558,7 @@ describe('nodes', function() {
                     right_source: SOURCE_ATM_MACHINES_DEF,
                     left_source_column: 'bank',
                     right_source_column: 'bank',
+                    left_source_columns: ['the_geom', 'indoor', 'cartodb_id', 'bank'],
                     right_source_columns: ['the_geom', 'indoor', 'cartodb_id']
                 }
             };
@@ -567,9 +568,9 @@ describe('nodes', function() {
                 params: {
                     left_source: merge,
                     right_source: SOURCE_ATM_MACHINES_DEF,
-                    join_operator: 'left',
                     left_source_column: 'bank',
                     right_source_column: 'bank',
+                    left_source_columns: ['the_geom', 'indoor', 'cartodb_id', 'bank'],
                     right_source_columns: ['the_geom', 'indoor', 'cartodb_id']
                 }
             };
@@ -579,26 +580,14 @@ describe('nodes', function() {
                 params: {
                     left_source: merge2,
                     right_source: SOURCE_ATM_MACHINES_DEF,
-                    join_operator: 'right',
                     left_source_column: 'bank',
                     right_source_column: 'bank',
+                    left_source_columns: ['the_geom', 'indoor', 'cartodb_id', 'bank'],
                     right_source_columns: ['the_geom', 'indoor', 'cartodb_id']
                 }
             };
 
-            var merge4 = {
-                type: 'merge',
-                params: {
-                    left_source: merge2,
-                    right_source: merge3,
-                    join_operator: 'inner',
-                    left_source_column: 'bank',
-                    right_source_column: 'bank',
-                    right_source_columns: ['the_geom', 'indoor', 'cartodb_id']
-                }
-            };
-
-            testHelper.createAnalyses(merge4, function(err, results) {
+            testHelper.createAnalyses(merge3, function(err, results) {
                 assert.ifError(err);
 
                 var rootNode = results.getRoot();


### PR DESCRIPTION
Changing the `right_X` columns into `left_right_X` caused issues if other analysis were done on top (if done using `right_X` both in running maps and `.carto` files (that stored and expected `right_X` not `left_right_X`).

Since the conflict with chained JOIN can be solved manually I'm reverting these changes so any working map and .carto file keeps working as expected without manual intervention. 

More detailed explanation in https://github.com/CartoDB/support/issues/1082#issuecomment-373672047