### PR TITLE
Remove metadata columns from street geocoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.62.1
+Release 2018-07-25
+  - Remove metadata columns from street level geocoding.
+
+
 ## 0.62.0
 Release 2018-07-19
   - Add a .npmignore to reduce size of npm package.

--- a/lib/node/nodes/georeference-street-address.js
+++ b/lib/node/nodes/georeference-street-address.js
@@ -95,12 +95,7 @@ var queryTemplate = Node.template(
     `
     SELECT
        {{=it.columns}},
-       _camshaft_georeference_street_address_analysis.the_geom,
-       st_transform(st_setsrid(_camshaft_georeference_street_address_analysis.the_geom, 4326), 3857)
-            as the_geom_webmercator,
-       _camshaft_georeference_street_address_analysis.__geocoding_meta_relevance,
-       _camshaft_georeference_street_address_analysis.__geocoding_meta_precision,
-       _camshaft_georeference_street_address_analysis.__geocoding_meta_match_types
+       _camshaft_georeference_street_address_analysis.the_geom
     FROM
        ({{=it.source}}) _cdb_analysis_source
        LEFT JOIN

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "camshaft",
-  "version": "0.62.0",
+  "version": "0.62.1",
   "description": "Analysis library to create data views from queries",
   "main": "./lib/analysis.js",
   "scripts": {


### PR DESCRIPTION
For modified analyses:

- [X] If it modifies the output columns, updates the analysis version --> in fact, the opposite: removes extra columns from 0.62.0
- [ ] ~Has tests to validate the result is the expected one.~

cc @dgaubert 