### PR TITLE
Get query from cache to compute output columns when building analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.62.2
 Release 2018-mm-dd
-
+  - Compute node's output columns from cached tables instead of final query to avoid missing columns when the schema of any analysis changes.
 
 ## 0.62.1
 Release 2018-07-25

--- a/lib/filter/query-builder.js
+++ b/lib/filter/query-builder.js
@@ -31,7 +31,6 @@ function createFilter(columns, filterDefinition) {
         throw new Error('Unknown filter type: ' + filterType);
     }
     var columnName = filterDefinition.column;
-
     var column = {
         name: columnName
     };

--- a/lib/filter/query-builder.js
+++ b/lib/filter/query-builder.js
@@ -31,6 +31,7 @@ function createFilter(columns, filterDefinition) {
         throw new Error('Unknown filter type: ' + filterType);
     }
     var columnName = filterDefinition.column;
+
     var column = {
         name: columnName
     };

--- a/lib/service/database.js
+++ b/lib/service/database.js
@@ -125,7 +125,8 @@ DatabaseService.prototype.createCacheTable = function(node, callback) {
 };
 
 DatabaseService.prototype.getColumns = function(node, callback) {
-    this.queryParser.getColumns(node.sql(), callback);
+    const applyFilters = false;
+    this.queryParser.getColumns(node.getQuery(applyFilters), callback);
 };
 
 DatabaseService.prototype.enqueue = function(queries, callback) {


### PR DESCRIPTION
Tested in https://github.com/CartoDB/Windshaft-cartodb/pull/1015

Related to #361 