### PR TITLE
Change error message for large payload errors

### DIFF
--- a/lib/postgresql/batch-client.js
+++ b/lib/postgresql/batch-client.js
@@ -18,6 +18,16 @@ function BatchClient(endpoint, username, apiKey, hostHeaderTemplate, inlineExecu
 
 module.exports = BatchClient;
 
+function batchErrorMessage(err, response) {
+    if (err && err.message) {
+        return err.message;
+    }
+    if (response.statusCode === 400 && response.match(/\bYour payload is too large\b/i)) {
+        return 'The analysis is too complex';
+    }
+    return 'Unable to enqueue SQL API batch job';
+}
+
 BatchClient.prototype.enqueue = function(queries, callback) {
     if (this.inlineExecution === true) {
         return runQueries(this.queryRunner, queries, callback);
@@ -40,7 +50,7 @@ BatchClient.prototype.enqueue = function(queries, callback) {
     request.post(enqueueRequest, function(err, response, job) {
         response = response || {};
         if (err || response.statusCode !== 201) {
-            return callback(new Error('Unable to enqueue SQL API batch job'));
+            return callback(new Error(batchErrorMessage(err, response)));
         }
 
         debug('Queued job: %j', job);


### PR DESCRIPTION
The batch SQL API returns a 400 when the queries payload is over 16KB. In this case the generic message about not being able to queue the job is not very useful.
