### PR TITLE
Improve Batch API error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.63.3
+Release 2019-02-dd
+  - Improve error message for exceeded batch SQL API payload size: add suggestions about what the user can do about it.
+
 ## 0.63.2
 Release 2018-12-19
   - Specific error message for exceeded batch SQL API payload size

--- a/lib/postgresql/batch-client.js
+++ b/lib/postgresql/batch-client.js
@@ -23,7 +23,8 @@ function batchErrorMessage(err, response) {
         return err.message;
     }
     if (response.statusCode === 400 && response.match(/\bYour payload is too large\b/i)) {
-        return 'The analysis SQL code couldn\'t be queued for execution because it is too complex';
+        return 'The analysis SQL code couldn\'t be queued for execution because it is too complex. ' +
+            'If you have multiple analyses please try simplifying or materialising some of them to reduce the payload.';
     }
     return 'Unable to enqueue SQL API batch job';
 }


### PR DESCRIPTION
Follow up of this PR: https://github.com/CartoDB/camshaft/pull/378

This improves the error message for exceeded batch SQL API payload size by adding suggestions about what the user can do about it.