### PR TITLE
Improve the performance of aggregate-intersection analysis

### DIFF
--- a/lib/node/nodes/aggregate-intersection.js
+++ b/lib/node/nodes/aggregate-intersection.js
@@ -10,7 +10,7 @@ var PARAMS = {
     aggregate_column: Node.PARAM.NULLABLE(Node.PARAM.STRING())
 };
 
-var AggregateIntersection = Node.create(TYPE, PARAMS, { cache: true, version: 4 });
+var AggregateIntersection = Node.create(TYPE, PARAMS, { cache: true, version: 3 });
 
 var ColumnNamer = require('../column-namer');
 

--- a/lib/node/nodes/aggregate-intersection.js
+++ b/lib/node/nodes/aggregate-intersection.js
@@ -10,7 +10,7 @@ var PARAMS = {
     aggregate_column: Node.PARAM.NULLABLE(Node.PARAM.STRING())
 };
 
-var AggregateIntersection = Node.create(TYPE, PARAMS, { cache: true, version: 3 });
+var AggregateIntersection = Node.create(TYPE, PARAMS, { cache: true, version: 4 });
 
 var ColumnNamer = require('../column-namer');
 
@@ -86,6 +86,9 @@ var densityQueryTemplate = Node.template([
 var queryAggregateTemplate = Node.template([
     'SELECT {{=it.columns}}',
     'FROM ({{=it.sourceQuery}}) _cdb_analysis_source, ({{=it.targetQuery}}) _cdb_analysis_target',
-    'WHERE ST_Intersects(_cdb_analysis_source.the_geom, _cdb_analysis_target.the_geom)',
+    'WHERE',
+    '       _cdb_analysis_source.the_geom && _cdb_analysis_target.the_geom',
+    '   AND',
+    '       ST_Intersects(_cdb_analysis_source.the_geom, _cdb_analysis_target.the_geom)',
     'GROUP BY {{=it.groupByColumns}}'
 ].join('\n'));


### PR DESCRIPTION
Add bbox filter before intersecting `geoms` to improve the performance of aggregate-intersection analysis
