### PR TITLE
Quote columns

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,45 @@
+dist: xenial
 language: node_js
-sudo: false
-dist: trusty
+sudo: required
 
 env:
-    - POSTGRESQL_VERSION="10"
+  global:
+    - PGUSER=postgres
+    - PGDATABASE=postgres
+    - PGOPTIONS='-c client_min_messages=NOTICE'
+    - PGPORT=5432
 
-node_js:
-  - "10"
+jobs:
+  include:
+    - env: POSTGRESQL_VERSION="10" POSTGIS_VERSION="2.5"
+      node_js: "10"
+    - env: POSTGRESQL_VERSION="11" POSTGIS_VERSION="2.5"
+      node_js: "10"
+    - env: POSTGRESQL_VERSION="12" POSTGIS_VERSION="2.5"
+      node_js: "10"
+    - env: POSTGRESQL_VERSION="12" POSTGIS_VERSION="3"
+      node_js: "10"
+    - env: POSTGRESQL_VERSION="11" POSTGIS_VERSION="2.5"
+      node_js: "12"
+    - env: POSTGRESQL_VERSION="12" POSTGIS_VERSION="3"
+      node_js: "12"
+  allow_failures:
+    - env: POSTGRESQL_VERSION="11" POSTGIS_VERSION="2.5"
+      node_js: "12"
+    - env: POSTGRESQL_VERSION="12" POSTGIS_VERSION="3"
+      node_js: "12"
 
 before_install:
   - sudo service postgresql stop;
-  - sudo apt-get install -y --allow-unauthenticated --no-install-recommends --no-install-suggests postgresql-$POSTGRESQL_VERSION postgresql-client-$POSTGRESQL_VERSION postgresql-server-dev-$POSTGRESQL_VERSION postgresql-$POSTGRESQL_VERSION-postgis-2.4 postgresql-$POSTGRESQL_VERSION-postgis-2.4-scripts postgresql-plpython-$POSTGRESQL_VERSION
-  - echo -e "# TYPE  DATABASE        USER            ADDRESS                 METHOD \nlocal   all             postgres                                trust\nlocal   all             all                                     trust\nhost    all             all             127.0.0.1/32            trust"  | sudo tee /etc/postgresql/$POSTGRESQL_VERSION/main/pg_hba.conf
-  - export PGPORT=`grep ^port /etc/postgresql/$POSTGRESQL_VERSION/main/postgresql.conf | awk '{print $3}'`
-  - sed -i 's/5432/'"$PGPORT"'/g' test/test-config.js
-  - sudo service postgresql restart $POSTGRESQL_VERSION;
+  - sudo apt-get remove postgresql* -y
+  - sudo apt-get install -y --allow-unauthenticated --no-install-recommends --no-install-suggests postgresql-$POSTGRESQL_VERSION postgresql-client-$POSTGRESQL_VERSION postgresql-server-dev-$POSTGRESQL_VERSION postgresql-common
+  - sudo apt-get install -y --allow-unauthenticated postgresql-$POSTGRESQL_VERSION-postgis-$POSTGIS_VERSION postgresql-$POSTGRESQL_VERSION-postgis-$POSTGIS_VERSION-scripts postgis
+  # For pre12, install plpython2. For PG12 install plpython3
+  - if [[ $POSTGRESQL_VERSION != '12' ]]; then sudo apt-get install -y postgresql-plpython-$POSTGRESQL_VERSION python python-redis; else sudo apt-get install -y postgresql-plpython3-12 python3 python3-redis; fi;
+  - sudo pg_dropcluster --stop $POSTGRESQL_VERSION main
+  - sudo rm -rf /etc/postgresql/$POSTGRESQL_VERSION /var/lib/postgresql/$POSTGRESQL_VERSION
+  - sudo pg_createcluster -u postgres $POSTGRESQL_VERSION main -- --auth-local trust
+  - sudo /etc/init.d/postgresql start $POSTGRESQL_VERSION || sudo journalctl -xe
+
+after_failure:
+  - pg_lsclusters

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.64.3
+Release 2019-XX-XX
+
+- Update `request` to `^2.85.0`.
+
 ## 0.64.2
 Release 2019-09-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Release 2019-XX-XX
 
 - Update `request` to `^2.85.0`.
 - Use plpython3u when testing against PG12+.
+- Use quoted identifiers for column names.
 
 ## 0.64.2
 Release 2019-09-13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 Release 2019-XX-XX
 
 - Update `request` to `^2.85.0`.
+- Use plpython3u when testing against PG12+.
 
 ## 0.64.2
 Release 2019-09-13

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SHELL=/bin/bash
 
 all:
-	npm install
+	npm ci
 
 clean:
 	@rm -rf ./node_modules

--- a/lib/node/column-namer.js
+++ b/lib/node/column-namer.js
@@ -9,6 +9,11 @@ module.exports = class ColumnNamer {
     }
 
     uniqueName(baseName) {
+        const quotedName = baseName.length > 2 && baseName[0] === '"' && baseName[baseName.length - 1] === '"';
+        if (quotedName)
+        {
+            baseName = baseName.substring(1, baseName.length - 1);
+        }
         baseName = baseName.toLowerCase();
         let name = baseName;
         let ok = this.isUnique(name);
@@ -17,12 +22,16 @@ module.exports = class ColumnNamer {
             name = baseName + '_' + (++count);
             ok = this.isUnique(name);
         }
+        if (quotedName)
+        {
+            name = `"${name}"`;
+        }
         this.columns.push(name);
         return name;
     }
 
     isUnique(name) {
-        return !this.columns.includes(name);
+        return !this.columns.includes(name) && !this.columns.includes(`"${name}"`);
     }
 
 };

--- a/lib/node/node.js
+++ b/lib/node/node.js
@@ -144,9 +144,8 @@ Node.prototype.getQuery = function(applyFilters) {
     return QueryBuilder.getSql(query, this.filters, applyFilters, this.schema);
 };
 
-Node.prototype.getColumns = function(skipTheGeoms = false, extraIgnored = []) {
-    let ignoredColumns = skipTheGeoms ? [ 'the_geom', 'the_geom_webmercator'] : [];
-    ignoredColumns = ignoredColumns.concat(extraIgnored);
+Node.prototype.getColumns = function({ ignoreGeomColumns = false, ignoredExtraColumns = [] } = {}) {
+    const ignoredColumns = (ignoreGeomColumns ? [ 'the_geom', 'the_geom_webmercator'] : []).concat(ignoredExtraColumns);
     return skipColumns(this.columns, ignoredColumns).map(col => `"${col.replace('"', '""')}"`);
 };
 
@@ -169,8 +168,17 @@ Node.prototype.getTypeSignature = function() {
     return this.typeSignature;
 };
 
+function stripQuotes(columnName) {
+    const quotedName = columnName.length > 2 && columnName[0] === '"' && columnName[columnName.length - 1] === '"';
+    if (quotedName)
+    {
+        return columnName.substring(1, columnName.length - 1);
+    }
+    return columnName;
+}
+
 function skipColumns(columnNames, ignoredColumns = []) {
-    return columnNames.filter(columnName => ignoredColumns.indexOf(columnName) === -1);
+    return columnNames.filter(columnName => !ignoredColumns.includes(stripQuotes(columnName)));
 }
 
 Node.prototype.setColumns = function(columns) {

--- a/lib/node/node.js
+++ b/lib/node/node.js
@@ -144,9 +144,10 @@ Node.prototype.getQuery = function(applyFilters) {
     return QueryBuilder.getSql(query, this.filters, applyFilters, this.schema);
 };
 
-Node.prototype.getColumns = function(skipTheGeoms) {
-    skipTheGeoms = skipTheGeoms || false;
-    return (skipTheGeoms) ? skipColumns(this.columns) : this.columns;
+Node.prototype.getColumns = function(skipTheGeoms = false, extraIgnored = []) {
+    let ignoredColumns = skipTheGeoms ? [ 'the_geom', 'the_geom_webmercator'] : [];
+    ignoredColumns = ignoredColumns.concat(extraIgnored);
+    return skipColumns(this.columns, ignoredColumns).map(col => `"${col.replace('"', '""')}"`);
 };
 
 Node.prototype.getFilters = function() {
@@ -168,14 +169,8 @@ Node.prototype.getTypeSignature = function() {
     return this.typeSignature;
 };
 
-var SKIP_COLUMNS = {
-    'the_geom': true,
-    'the_geom_webmercator': true
-};
-
-function skipColumns(columnNames) {
-    return columnNames
-        .filter(function(columnName) { return !SKIP_COLUMNS[columnName]; });
+function skipColumns(columnNames, ignoredColumns = []) {
+    return columnNames.filter(columnName => ignoredColumns.indexOf(columnName) === -1);
 }
 
 Node.prototype.setColumns = function(columns) {

--- a/lib/node/nodes/aggregate-intersection.js
+++ b/lib/node/nodes/aggregate-intersection.js
@@ -36,7 +36,7 @@ AggregateIntersection.prototype.sql = function() {
         finalColumnName = 'count_vals';
     }
 
-    finalColumnName = columnNamer.uniqueName(finalColumnName);
+    finalColumnName = columnNamer.uniqueName(`"${finalColumnName}"`);
 
     var aggregateFunctionColumn = aggregateFunctionTemplate({
         aggregateFunction: this.aggregate_function,
@@ -47,7 +47,7 @@ AggregateIntersection.prototype.sql = function() {
     columns.push(aggregateFunctionColumn);
 
     if (this.aggregate_function === 'count') {
-        var count_density_column = columnNamer.uniqueName('count_vals_density');
+        var count_density_column = columnNamer.uniqueName('"count_vals_density"');
         var aggregateDensityColumn = densityQueryTemplate({
             aggregateFunction: this.aggregate_function,
             qualifiedAggregateColumn: qualifiedAggregateColumn,

--- a/lib/node/nodes/buffer.js
+++ b/lib/node/nodes/buffer.js
@@ -80,13 +80,15 @@ var isolineDataRangeTpl = Node.template(
 );
 
 Buffer.prototype.isolinesQuery = function() {
-    var _columns = [
+    const ignoredExtraColumns = ['cartodb_id'];
+    const ignoreGeomColumns = true;
+    const _columns = [
         'the_geom AS center',
         'row_number() over() AS cartodb_id',
         isolineGeomTpl({ _radius: this.radius, _isolines: this.isolines }),
         isolineDataRangeTpl({ _radius: this.radius, _isolines: this.isolines })
     ]
-    .concat(this.source.getColumns(true).filter(columnName => columnName !== 'cartodb_id'));
+    .concat(this.source.getColumns(ignoreGeomColumns, ignoredExtraColumns));
     
     return isolinesQueryTpl({
         _columns: _columns.join(','),

--- a/lib/node/nodes/buffer.js
+++ b/lib/node/nodes/buffer.js
@@ -47,7 +47,7 @@ var radiusQueryTpl = Node.template([
 Buffer.prototype.radiusQuery = function() {
     var _columns = [
         'ST_Buffer(the_geom::geography, ' + this.radius + ')::geometry the_geom'
-    ].concat(this.source.getColumns(true));
+    ].concat(this.source.getColumns({ ignoreGeomColumns: true }));
     return radiusQueryTpl({
         _columns: _columns.join(','),
         _query: this.source.getQuery()
@@ -80,15 +80,13 @@ var isolineDataRangeTpl = Node.template(
 );
 
 Buffer.prototype.isolinesQuery = function() {
-    const ignoredExtraColumns = ['cartodb_id'];
-    const ignoreGeomColumns = true;
     const _columns = [
         'the_geom AS center',
         'row_number() over() AS cartodb_id',
         isolineGeomTpl({ _radius: this.radius, _isolines: this.isolines }),
         isolineDataRangeTpl({ _radius: this.radius, _isolines: this.isolines })
     ]
-    .concat(this.source.getColumns(ignoreGeomColumns, ignoredExtraColumns));
+    .concat(this.source.getColumns({ ignoreGeomColumns: true, ignoredExtraColumns:  ['cartodb_id'] }));
     
     return isolinesQueryTpl({
         _columns: _columns.join(','),

--- a/lib/node/nodes/closest.js
+++ b/lib/node/nodes/closest.js
@@ -46,10 +46,8 @@ Closest.prototype.sql = function () {
     var query = closestTemplate({
         squery: this.source.getQuery(),
         tquery: this.target.getQuery(),
-        tcolumns: this.target.getColumns(false, ['cartodb_id'])
-        .map(function (column2) {
-            return 't.' + column2;
-        }).join(', '),
+        tcolumns: this.target.getColumns({ ignoreGeomColumns: false, ignoredExtraColumns:  ['cartodb_id'] })
+                             .map(column => `t.${column}`).join(', '),
         responses: this.responses,
         category: this.category
     });

--- a/lib/node/nodes/closest.js
+++ b/lib/node/nodes/closest.js
@@ -46,9 +46,8 @@ Closest.prototype.sql = function () {
     var query = closestTemplate({
         squery: this.source.getQuery(),
         tquery: this.target.getQuery(),
-        tcolumns: this.target.getColumns().filter(function (column1) {
-            return column1 !== 'cartodb_id';
-        }).map(function (column2) {
+        tcolumns: this.target.getColumns(false, ['cartodb_id'])
+        .map(function (column2) {
             return 't.' + column2;
         }).join(', '),
         responses: this.responses,

--- a/lib/node/nodes/georeference-admin-region.js
+++ b/lib/node/nodes/georeference-admin-region.js
@@ -19,7 +19,7 @@ module.exports = GeoreferenceAdminRegion;
 GeoreferenceAdminRegion.prototype.sql = function() {
     var sql = queryTemplate({
         source: this.source.getQuery(),
-        columns: this.source.getColumns(true).join(', '),
+        columns: this.source.getColumns({ ignoreGeomColumns: true }).join(', '),
         geocoder_params: this.getGeocoderParams().join(', ')
     });
 

--- a/lib/node/nodes/georeference-city.js
+++ b/lib/node/nodes/georeference-city.js
@@ -28,7 +28,7 @@ module.exports = GeoreferenceCity;
 GeoreferenceCity.prototype.sql = function() {
     var sql = queryTemplate({
         source: this.source.getQuery(),
-        columns: this.source.getColumns(true).join(', '),
+        columns: this.source.getColumns({ ignoreGeomColumns: true }).join(', '),
         geocoder_params: this.getGeocoderParams().join(', ')
     });
 

--- a/lib/node/nodes/georeference-country.js
+++ b/lib/node/nodes/georeference-country.js
@@ -19,7 +19,7 @@ module.exports = GeoreferenceCountry;
 GeoreferenceCountry.prototype.sql = function() {
     var sql = queryTemplate({
         source: this.source.getQuery(),
-        columns: this.source.getColumns(true).join(', '),
+        columns: this.source.getColumns({ ignoreGeomColumns: true }).join(', '),
         country: this.country_column
     });
 

--- a/lib/node/nodes/georeference-ip-address.js
+++ b/lib/node/nodes/georeference-ip-address.js
@@ -15,7 +15,7 @@ module.exports = GeoreferenceIpAddress;
 GeoreferenceIpAddress.prototype.sql = function() {
     return queryTemplate({
         source: this.source.getQuery(),
-        columns: this.source.getColumns(true).join(', '),
+        columns: this.source.getColumns({ ignoreGeomColumns: true }).join(', '),
         ip_address: this.ip_address
     });
 };

--- a/lib/node/nodes/georeference-long-lat.js
+++ b/lib/node/nodes/georeference-long-lat.js
@@ -30,7 +30,7 @@ var georeferenceLongLatTemplate = Node.template([
 GeoreferenceLongLat.prototype.sql = function(){
     return georeferenceLongLatTemplate({
         source: this.source.getQuery(),
-        columns: this.source.getColumns(true).join(', '),
+        columns: this.source.getColumns({ ignoreGeomColumns: true }).join(', '),
         longitude: this.longitude,
         latitude: this.latitude
     });

--- a/lib/node/nodes/georeference-postal-code.js
+++ b/lib/node/nodes/georeference-postal-code.js
@@ -30,7 +30,7 @@ module.exports = GeoreferencePostalCode;
 GeoreferencePostalCode.prototype.sql = function() {
     var sql = queryTemplate({
         source: this.source.getQuery(),
-        columns: this.source.getColumns(true).join(', '),
+        columns: this.source.getColumns({ ignoreGeomColumns: true }).join(', '),
         geocoder_function: getGecoderFunction(this.output_geometry_type),
         geocoder_params: this.getGeocoderParams().join(', ')
     });

--- a/lib/node/nodes/georeference-street-address.js
+++ b/lib/node/nodes/georeference-street-address.js
@@ -29,7 +29,7 @@ module.exports = GeoreferenceStreetAddress;
 GeoreferenceStreetAddress.prototype.sql = function() {
     var sql = queryTemplate({
         source: this.source.getQuery(),
-        columns: this.source.getColumns(true).join(', '),
+        columns: this.source.getColumns({ ignoreGeomColumns: true }).join(', '),
         country_column: this.getFunctionParam('country'),
         state_column: this.getFunctionParam('state'),
         city_column: this.getFunctionParam('city'),

--- a/lib/node/nodes/intersection.js
+++ b/lib/node/nodes/intersection.js
@@ -17,7 +17,7 @@ module.exports = Intersection;
 Intersection.prototype.sql = function() {
 
     if (!this.source_columns.length) {
-        this.source_columns = this.source.getColumns(true);
+        this.source_columns = this.source.getColumns({ ignoreGeomColumns: true });
     }
 
     var prefixedSourceColumns = this.source_columns.map(function (name) {

--- a/lib/node/nodes/intersection.js
+++ b/lib/node/nodes/intersection.js
@@ -21,7 +21,14 @@ Intersection.prototype.sql = function() {
     }
 
     var prefixedSourceColumns = this.source_columns.map(function (name) {
-        return '_cdb_analysis_source.' + name + ' as source_' + name;
+        let unquoted_name = name;
+        const quotedName = name.length > 2 && name[0] === '"' && name[name.length - 1] === '"';
+        if (quotedName)
+        {
+            unquoted_name = name.substring(1, name.length - 1);
+        }
+
+        return `_cdb_analysis_source.${name} as "source_${unquoted_name}"`;
     });
 
     var sql = queryTemplate({

--- a/lib/node/nodes/line-source-to-target.js
+++ b/lib/node/nodes/line-source-to-target.js
@@ -37,12 +37,11 @@ module.exports = LineSourceToTarget;
 
 LineSourceToTarget.prototype.sql = function() {
     var sql;
-    var skipGeoms = true;
     var templateContext = {
         source: this.source.getQuery(),
         source_column: this.source_column,
         source_alias: SOURCE_ALIAS,
-        source_columns: this.source.getColumns(skipGeoms).map(function (column) {
+        source_columns: this.source.getColumns({ ignoreGeomColumns: true }).map(function (column) {
             return SOURCE_ALIAS + '.' + column;
         }).join(', '),
         target: this.target.getQuery(),

--- a/lib/node/nodes/line-to-column.js
+++ b/lib/node/nodes/line-to-column.js
@@ -14,10 +14,11 @@ var LineToColumn = Node.create(TYPE, PARAMS);
 module.exports = LineToColumn;
 
 LineToColumn.prototype.sql = function() {
-    var skipGeoms = true;
     var sql = linetoColumn({
         source: this.source.getQuery(),
-        columns: this.source.getColumns(skipGeoms, [this.target_column]).join(', '),
+        columns: this.source.getColumns({ 
+            ignoreGeomColumns: true,
+            ignoredExtraColumns: [this.target_column] }).join(', '),
         target_column: this.target_column
     });
 

--- a/lib/node/nodes/line-to-column.js
+++ b/lib/node/nodes/line-to-column.js
@@ -14,14 +14,11 @@ var LineToColumn = Node.create(TYPE, PARAMS);
 module.exports = LineToColumn;
 
 LineToColumn.prototype.sql = function() {
-    var self = this;
     var skipGeoms = true;
     var sql = linetoColumn({
         source: this.source.getQuery(),
-        columns: this.source.getColumns(skipGeoms).filter(function (column) {
-            return self.target_column !== column;
-        }).join(', '),
-        target_column: this.target_column,
+        columns: this.source.getColumns(skipGeoms, [this.target_column]).join(', '),
+        target_column: this.target_column
     });
 
     debug(sql);

--- a/lib/node/nodes/line-to-single-point.js
+++ b/lib/node/nodes/line-to-single-point.js
@@ -15,10 +15,9 @@ var LineToSinglePoint = Node.create(TYPE, PARAMS);
 module.exports = LineToSinglePoint;
 
 LineToSinglePoint.prototype.sql = function() {
-    var skipTheGeoms = true;
     var sql = lineToSinglePointQueryTemplate({
         source: this.source.getQuery(),
-        columns: this.source.getColumns(skipTheGeoms).join(', '),
+        columns: this.source.getColumns({ ignoreGeomColumns: true }).join(', '),
         destination_longitude: this.destination_longitude,
         destination_latitude: this.destination_latitude
     });

--- a/lib/node/nodes/link-by-line.js
+++ b/lib/node/nodes/link-by-line.js
@@ -31,22 +31,22 @@ var linkByLineTemplate = Node.template([
 ].join('\n'));
 
 var featureColumns = function(columns,prefix){
-    return columns.map(function(col){
-        return prefix + '.' + col + ' as ' + prefix + '_' + col;
-    }).join(',');
+    return columns.map(col => `${prefix}.${col} as ${prefix}_${col}`).join(',');
 };
 
 LinkByLine.prototype.sql = function(){
-    var lineFunc = this.use_great_circle ? 'CDB_GreatCircle' : 'ST_MakeLine';
-    const ignoreGeom = true;
-    const ignoredCols = ['cartodb_id'];
+    const lineFunc = this.use_great_circle ? 'CDB_GreatCircle' : 'ST_MakeLine';
+    const sourceColumns = this.source_points.getColumns({ ignoreGeomColumns: true });
+    const destinationColumns = this.destination_points.getColumns(
+            { ignoreGeomColumns: true,
+              ignoredExtraColumns:  ['cartodb_id'] });
     return linkByLineTemplate({
         sourceQuery: this.source_points.getQuery(),
         destinationQuery: this.destination_points.getQuery(),
         sourceColumn: this.source_column,
         destinationColumn: this.destination_column,
-        sourceColumns: this.source_points.getColumns(ignoreGeom).map(function(c) { return 'source.' + c; }),
-        destinationColumns: featureColumns(this.destination_points.getColumns(ignoreGeom, ignoredCols), 'destination'),
+        sourceColumns: sourceColumns.map(c => `source.${c}`),
+        destinationColumns: featureColumns(destinationColumns, 'destination'),
         lineFunc: lineFunc
     });
 };

--- a/lib/node/nodes/link-by-line.js
+++ b/lib/node/nodes/link-by-line.js
@@ -38,15 +38,15 @@ var featureColumns = function(columns,prefix){
 
 LinkByLine.prototype.sql = function(){
     var lineFunc = this.use_great_circle ? 'CDB_GreatCircle' : 'ST_MakeLine';
-    const ignoreGeomColumns = true;
-    const ignoredColumns = ['cartodb_id'];
+    const ignoreGeom = true;
+    const ignoredCols = ['cartodb_id'];
     return linkByLineTemplate({
         sourceQuery: this.source_points.getQuery(),
         destinationQuery: this.destination_points.getQuery(),
         sourceColumn: this.source_column,
         destinationColumn: this.destination_column,
-        sourceColumns: this.source_points.getColumns(ignoreGeomColumns).map(function(c) { return 'source.' + c; }),
-        destinationColumns: featureColumns(this.destination_points.getColumns(ignoreGeomColumns, ignoredColumns), 'destination'),
+        sourceColumns: this.source_points.getColumns(ignoreGeom).map(function(c) { return 'source.' + c; }),
+        destinationColumns: featureColumns(this.destination_points.getColumns(ignoreGeom, ignoredCols), 'destination'),
         lineFunc: lineFunc
     });
 };

--- a/lib/node/nodes/link-by-line.js
+++ b/lib/node/nodes/link-by-line.js
@@ -31,22 +31,22 @@ var linkByLineTemplate = Node.template([
 ].join('\n'));
 
 var featureColumns = function(columns,prefix){
-    return columns.filter(function(col) {
-        return ['cartodb_id'].indexOf(col) === -1;
-    }).map(function(col){
+    return columns.map(function(col){
         return prefix + '.' + col + ' as ' + prefix + '_' + col;
     }).join(',');
 };
 
 LinkByLine.prototype.sql = function(){
     var lineFunc = this.use_great_circle ? 'CDB_GreatCircle' : 'ST_MakeLine';
+    const ignoreGeomColumns = true;
+    const ignoredColumns = ['cartodb_id'];
     return linkByLineTemplate({
         sourceQuery: this.source_points.getQuery(),
         destinationQuery: this.destination_points.getQuery(),
         sourceColumn: this.source_column,
         destinationColumn: this.destination_column,
-        sourceColumns: this.source_points.getColumns(true).map(function(c) { return 'source.' + c; }),
-        destinationColumns: featureColumns(this.destination_points.getColumns(true), 'destination'),
+        sourceColumns: this.source_points.getColumns(ignoreGeomColumns).map(function(c) { return 'source.' + c; }),
+        destinationColumns: featureColumns(this.destination_points.getColumns(ignoreGeomColumns, ignoredColumns), 'destination'),
         lineFunc: lineFunc
     });
 };

--- a/lib/node/nodes/merge.js
+++ b/lib/node/nodes/merge.js
@@ -110,8 +110,8 @@ function setAliasTo(columns, alias, as) {
 
         if (as === 'left') {
             // only set alias to cartodb_id column
-            if (column.endsWith('cartodb_id')) {
-                qualifiedColumnName += ' as ' + as + '_' + column;
+            if (column.endsWith('cartodb_id"') || column.endsWith('cartodb_id')) {
+                qualifiedColumnName += ' as ' + column.replace('cartodb_id', '_cartodb_id');
             }
         } else if (as) {
             qualifiedColumnName += ' as ' + as + '_' + column;

--- a/lib/node/nodes/merge.js
+++ b/lib/node/nodes/merge.js
@@ -70,7 +70,7 @@ function isNotAGeometryColumn(column) {
 
 Merge.prototype._getLeftColumns = function(left_alias) {
     var leftColumns = (this.left_source_columns === null) ?
-        this.left_source.getColumns(true) :
+        this.left_source.getColumns({ ignoreGeomColumns: true }) :
         this.left_source_columns;
 
     if (this.source_geometry === 'left_source') {

--- a/lib/node/nodes/routing-sequential.js
+++ b/lib/node/nodes/routing-sequential.js
@@ -18,7 +18,7 @@ module.exports = RoutingSequential;
 RoutingSequential.prototype.sql = function() {
     return routingSequentialQueryTemplate({
         source: this.source.getQuery(),
-        columns: this.source.getColumns(true).join(', '),
+        columns: this.source.getColumns({ ignoreGeomColumns: true }).join(', '),
         mode: this.mode,
         mode_type: 'shortest',
         units: this.units,

--- a/lib/node/nodes/routing-to-layer-all-to-all.js
+++ b/lib/node/nodes/routing-to-layer-all-to-all.js
@@ -41,10 +41,10 @@ RoutingToLayerAllToAll.prototype.sql = function() {
         source: this.source.getQuery(),
         source_alias: SOURCE_ALIAS,
         source_column: this.source_column,
-        source_columns: this.source.getColumns(true).map(function (column) {
+        source_columns: this.source.getColumns({ ignoreGeomColumns: true }).map(function (column) {
             return SOURCE_ALIAS + '.' + column;
         }).join(', '),
-        final_columns: this.source.getColumns(true).map(function (column) {
+        final_columns: this.source.getColumns({ ignoreGeomColumns: true }).map(function (column) {
             return OURTER_ALIAS + '.' + column;
         }).join(', '),
         final_alias: OURTER_ALIAS,

--- a/lib/node/nodes/routing-to-single-point.js
+++ b/lib/node/nodes/routing-to-single-point.js
@@ -18,7 +18,7 @@ module.exports = RoutingToSinglePoint;
 RoutingToSinglePoint.prototype.sql = function() {
     return routingToSinglePointQueryTemplate({
         source: this.source.getQuery(),
-        columns: this.source.getColumns(true).join(', '),
+        columns: this.source.getColumns({ ignoreGeomColumns: true }).join(', '),
         destination_longitude: this.destination_longitude,
         destination_latitude: this.destination_latitude,
         mode: this.mode,

--- a/lib/node/nodes/trade-area.js
+++ b/lib/node/nodes/trade-area.js
@@ -20,10 +20,11 @@ module.exports = TradeArea;
 
 
 TradeArea.prototype.sql = function() {
-    const dropGeomColumns = true;
     const dropColumns = ['cartodb_id', 'source_cartodb_id', 'center', 'data_range', 'the_geom'];
     var template = this.dissolved ? tradeAreasDissolvedQueryTemplate : tradeAreasQueryTemplate;
-    const columnsQuery = this.source.getColumns(dropGeomColumns, dropColumns).join(', ');
+    const columnsQuery = this.source.getColumns(
+            { ignoreGeomColumns: true,
+              ignoredExtraColumns: dropColumns }).join(', ');
 
     return template({
         pointsQuery: this.source.getQuery(),

--- a/lib/node/nodes/trade-area.js
+++ b/lib/node/nodes/trade-area.js
@@ -18,20 +18,12 @@ var TradeArea = Node.create(TYPE, PARAMS, { cache: true, version: 4, tags: ['io4
 
 module.exports = TradeArea;
 
-const DROP_COLUMN = {
-    'cartodb_id' : true,
-    'source_cartodb_id' : true,
-    'center' : true,
-    'data_range' : true,
-    'the_geom' : true
-};
 
 TradeArea.prototype.sql = function() {
+    const dropGeomColumns = true;
+    const dropColumns = ['cartodb_id', 'source_cartodb_id', 'center', 'data_range', 'the_geom'];
     var template = this.dissolved ? tradeAreasDissolvedQueryTemplate : tradeAreasQueryTemplate;
-    const columnsQuery = this.source.getColumns(true)
-        .filter(columnName => !(DROP_COLUMN[columnName]))
-        .map(columnName => `"${columnName}"`)
-        .join(', ');
+    const columnsQuery = this.source.getColumns(dropGeomColumns, dropColumns).join(', ');
 
     return template({
         pointsQuery: this.source.getQuery(),

--- a/lib/node/validator/schema.js
+++ b/lib/node/validator/schema.js
@@ -12,7 +12,7 @@ function SchemaValidator(requiredColumns) {
 SchemaValidator.prototype.isValid = function(node, errors) {
     var missingColumnsErrors = [];
     this.requiredColumns.forEach(function(column) {
-        if (node.schema.hasOwnProperty(column.name)) {
+        if (node.schema.hasOwnProperty(column.name) || node.schema.hasOwnProperty(`"${column.name}"`)) {
             if (node.schema[column.name] !== column.type) {
                 missingColumnsErrors.push(
                     new Error('Invalid type for column "' + column.name +

--- a/lib/postgresql/queries.js
+++ b/lib/postgresql/queries.js
@@ -4,6 +4,11 @@ const SubstitutionTokens = require('cartodb-query-tables').utils.substitutionTok
 
 function pgQuoteCastMapper(cast) {
     return function(input) {
+        const quotedInput = input.length > 2 && input[0] === '"' && input[input.length - 1] === '"';
+        if (quotedInput)
+        {
+            input = input.substring(1, input.length - 1);
+        }
         return '\'' + input + '\'' + (cast ? ('::' + cast) : '');
     };
 }

--- a/lib/postgresql/query-parser.js
+++ b/lib/postgresql/query-parser.js
@@ -26,15 +26,3 @@ QueryParser.prototype.getColumns = function(query, callback) {
         return callback(err, fields);
     });
 };
-
-QueryParser.prototype.getColumnNames = function(query, callback) {
-    this.getColumns(query, function(err, columns) {
-        if (err) {
-            return callback(err);
-        }
-
-        return callback(null, columns.map(function(column) {
-            return column.name;
-        }));
-    });
-};

--- a/package-lock.json
+++ b/package-lock.json
@@ -239,9 +239,9 @@
       "optional": true
     },
     "combined-stream": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
-      "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -321,9 +321,9 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "cryptiles": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
-      "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.4.tgz",
+      "integrity": "sha512-8I1sgZHfVwcSOY6mSGpVU3lw/GSIZvusg8dD2+OGehCJpOhQRLNcH0qb9upQnOH4XhgxxFJSg6E2kx95deb1Tw==",
       "requires": {
         "boom": "5.x.x"
       },
@@ -574,7 +574,7 @@
     },
     "fast-deep-equal": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
       "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
     },
     "fast-json-stable-stringify": {
@@ -1021,16 +1021,16 @@
       "dev": true
     },
     "mime-db": {
-      "version": "1.37.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
-      "integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg=="
+      "version": "1.42.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.42.0.tgz",
+      "integrity": "sha512-UbfJCR4UAVRNgMpfImz05smAXK7+c+ZntjaA26ANtkXLlOe947Aag5zdIcKQULAiF9Cq4WxBi9jUs5zkA84bYQ=="
     },
     "mime-types": {
-      "version": "2.1.21",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
-      "integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
+      "version": "2.1.25",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.25.tgz",
+      "integrity": "sha512-5KhStqB5xpTAeGqKBAMgwaYMnQik7teQN4IAzC7npDv6kzeU6prfkR67bc87J1kWMPGkoaZSq1npmexMgkmEVg==",
       "requires": {
-        "mime-db": "~1.37.0"
+        "mime-db": "1.42.0"
       }
     },
     "minimatch": {
@@ -1456,7 +1456,7 @@
     },
     "request": {
       "version": "2.85.0",
-      "resolved": "http://registry.npmjs.org/request/-/request-2.85.0.tgz",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.85.0.tgz",
       "integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
       "requires": {
         "aws-sign2": "~0.7.0",
@@ -1575,9 +1575,9 @@
       "dev": true
     },
     "sshpk": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.15.2.tgz",
-      "integrity": "sha512-Ra/OXQtuh0/enyl4ETZAfTaeksa6BXks5ZcjpSUNrjBr0DvrJKX+1fsKDPpT9TBXgHAFsa4510aNVgI8g/+SzA==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
       "requires": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -1737,9 +1737,9 @@
       "optional": true
     },
     "uuid": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
+      "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ=="
     },
     "verror": {
       "version": "1.10.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "cartodb-query-tables": "^0.6.1",
     "debug": "^3.1.0",
     "dot": "^1.0.3",
-    "request": "2.85.0"
+    "request": "^2.85.0"
   },
   "devDependencies": {
     "cartodb-redis": "^0.13.0",

--- a/test/acceptance/sql/DEP_EXT_python_weak_kmeans.sql
+++ b/test/acceptance/sql/DEP_EXT_python_weak_kmeans.sql
@@ -1,37 +1,84 @@
-CREATE OR REPLACE FUNCTION DEP_EXT_python_weak_kmeans(
-        operation text,
-        table_name text,
-        source_query text, source_columns text[],
-        clusters int
-    )
-    RETURNS VOID AS $$
-        def my_poor_cluster_impl(row):
-            # LOL.
-            return int(max(0, (row['x'] / (360 / clusters) + (clusters / 2)) - 1))
+DO $python$
+BEGIN
+    IF current_setting('server_version_num')::integer > 120000 THEN
+        CREATE OR REPLACE FUNCTION DEP_EXT_python_weak_kmeans(
+            operation text,
+            table_name text,
+            source_query text, source_columns text[],
+            clusters int
+        )
+        RETURNS VOID AS
+        $fdef$
+            def my_poor_cluster_impl(row):
+                # LOL.
+                return int(max(0, (row['x'] / (360 / clusters) + (clusters / 2)) - 1))
 
-        if operation == 'create':
-            plpy.execute(
-                'CREATE TABLE {table_name} AS SELECT *, 0 as cluster_no FROM ({source_query}) _q LIMIT 0'
-                .format(table_name=table_name, source_query=source_query)
-            )
+            if operation == 'create':
+                plpy.execute(
+                    'CREATE TABLE {table_name} AS SELECT *, 0 as cluster_no FROM ({source_query}) _q LIMIT 0'
+                    .format(table_name=table_name, source_query=source_query)
+                )
 
-        if operation == 'populate':
-            # Populate the table with the original one.
-            plpy.execute(
-                '''INSERT INTO {table_name} SELECT *, 0 as cluster_no FROM ({source_query}) _q'''
-                .format(table_name=table_name, source_query=source_query)
-            )
-            # Retrieve with some extra information based on st_x/st_y Postgis functions.
-            # We already can work with the new table.
-            rv = plpy.execute(
-                'select st_x(the_geom) x, st_y(the_geom) y, * FROM {table_name}'
-                .format(table_name=table_name)
-            )
-            plan = plpy.prepare(
-                'UPDATE {table_name} SET cluster_no = $1 WHERE cartodb_id = $2'.format(table_name=table_name),
-                ['numeric', 'numeric']
-            )
-            for row in rv:
-                cluster = my_poor_cluster_impl(row)
-                plpy.execute(plan, [cluster, row['cartodb_id']])
-$$ LANGUAGE plpythonu;
+            if operation == 'populate':
+                # Populate the table with the original one.
+                plpy.execute(
+                    '''INSERT INTO {table_name} SELECT *, 0 as cluster_no FROM ({source_query}) _q'''
+                    .format(table_name=table_name, source_query=source_query)
+                )
+                # Retrieve with some extra information based on st_x/st_y Postgis functions.
+                # We already can work with the new table.
+                rv = plpy.execute(
+                    'select st_x(the_geom) x, st_y(the_geom) y, * FROM {table_name}'
+                    .format(table_name=table_name)
+                )
+                plan = plpy.prepare(
+                    'UPDATE {table_name} SET cluster_no = $1 WHERE cartodb_id = $2'.format(table_name=table_name),
+                    ['numeric', 'numeric']
+                )
+                for row in rv:
+                    cluster = my_poor_cluster_impl(row)
+                    plpy.execute(plan, [cluster, row['cartodb_id']])
+        $fdef$ LANGUAGE plpython3u;
+    ELSE
+        CREATE OR REPLACE FUNCTION DEP_EXT_python_weak_kmeans(
+            operation text,
+            table_name text,
+            source_query text, source_columns text[],
+            clusters int
+        )
+        RETURNS VOID AS
+        $fdef$
+            def my_poor_cluster_impl(row):
+                # LOL.
+                return int(max(0, (row['x'] / (360 / clusters) + (clusters / 2)) - 1))
+
+            if operation == 'create':
+                plpy.execute(
+                    'CREATE TABLE {table_name} AS SELECT *, 0 as cluster_no FROM ({source_query}) _q LIMIT 0'
+                    .format(table_name=table_name, source_query=source_query)
+                )
+
+            if operation == 'populate':
+                # Populate the table with the original one.
+                plpy.execute(
+                    '''INSERT INTO {table_name} SELECT *, 0 as cluster_no FROM ({source_query}) _q'''
+                    .format(table_name=table_name, source_query=source_query)
+                )
+                # Retrieve with some extra information based on st_x/st_y Postgis functions.
+                # We already can work with the new table.
+                rv = plpy.execute(
+                    'select st_x(the_geom) x, st_y(the_geom) y, * FROM {table_name}'
+                    .format(table_name=table_name)
+                )
+                plan = plpy.prepare(
+                    'UPDATE {table_name} SET cluster_no = $1 WHERE cartodb_id = $2'.format(table_name=table_name),
+                    ['numeric', 'numeric']
+                )
+                for row in rv:
+                    cluster = my_poor_cluster_impl(row)
+                    plpy.execute(plan, [cluster, row['cartodb_id']])
+        $fdef$ LANGUAGE plpythonu;
+    END IF;
+END$python$;
+
+

--- a/test/fixtures/cdb_dataservices_client/obs_getmeasure.sql
+++ b/test/fixtures/cdb_dataservices_client/obs_getmeasure.sql
@@ -15,6 +15,17 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
+-- Create geomval if it doesn't exist (in postgis 3+ it only exists in postgis_raster)
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'geomval') THEN
+        CREATE TYPE geomval AS (
+            geom geometry,
+            val double precision
+        );
+    END IF;
+END$$;
+
 CREATE OR REPLACE FUNCTION cdb_dataservices_client._OBS_GetData_exception_safe(
   geomvals geomval[],
   params json,

--- a/test/fixtures/plpythonu_extension.sql
+++ b/test/fixtures/plpythonu_extension.sql
@@ -1,1 +1,8 @@
-CREATE EXTENSION plpythonu;
+DO $$
+BEGIN
+    IF current_setting('server_version_num')::integer > 120000 THEN
+        CREATE EXTENSION plpython3u;
+    ELSE
+        CREATE EXTENSION plpythonu;
+    END IF;
+END$$;

--- a/test/integration/nodes.js
+++ b/test/integration/nodes.js
@@ -17,8 +17,8 @@ describe('nodes', function() {
         Analysis.create(testConfig, definition, callback);
     }
 
-    var QUERY_ATM_MACHINES = 'select * from atm_machines';
-    var QUERY_POSTAL_CODES = 'select * from postal_codes';
+    var QUERY_ATM_MACHINES = 'select 0 as begin, * from atm_machines';
+    var QUERY_POSTAL_CODES = 'select 1 as desc, * from postal_codes';
 
     var SOURCE_ATM_MACHINES_DEF = {
         type: 'source',

--- a/test/integration/query-parser.js
+++ b/test/integration/query-parser.js
@@ -44,15 +44,4 @@ describe('query-parser', function() {
         });
     });
 
-    it('should return a list of columns names', function(done) {
-        var query = 'select cartodb_id, the_geom_webmercator from atm_machines';
-        queryParser.getColumnNames(query, function(err, columnNames) {
-            assert.ok(!err, err);
-
-            assert.deepEqual(columnNames, ['cartodb_id', 'the_geom_webmercator']);
-
-            done();
-        });
-    });
-
 });

--- a/test/unit/column-namer.js
+++ b/test/unit/column-namer.js
@@ -27,4 +27,10 @@ describe('column-namer', function() {
         assert.equal(namer.uniqueName('col4'), 'col4');
     });
 
+    it('should work with quoted columns', function() {
+        var namer = new ColumnNamer(['"col1"', '"col2"' ]);
+        assert.equal(namer.uniqueName('"col1"'), '"col1_2"');
+        assert.equal(namer.uniqueName('"col2"'), '"col2_2"');
+    });
+
 });


### PR DESCRIPTION
What this does:
- Updates request (vulnerability).
- Updates travis to test against PG12 (ok) and node12 (not ok, so allowed_failures for now).
- Adapts test to use plpython3u instead of plpythonu for PG12+.
- Adapts test to not require postgis_raster in postgis 3+
- Adapts the analyses to use quoted identifiers. This is done in order to avoid issues with reserved words. To maintain retro-compatibility the functions that modify this ids are changed to support both unquoted and quoted identifiers. Fixes https://github.com/CartoDB/camshaft/issues/386

For modified analyses:

- [x] If it modifies the output columns, updates the analysis version: ~Need to test if this is necessary since **all analyses are changed**, but the ids are the same with quotes.~ Tested in staging and it's not necessary.
- [x] Has tests to validate the result is the expected one.