### PR TITLE
Create geomval in cdb_dataservices_client schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 0.65.4
 Release 2020-mm-dd
 
+- Minor changes in the tests to create the geomval type, if necessary, in the cdb_dataservices_client schema. This is done to match the behaviour of that extension.
+
 ## 0.65.3
 Release 2020-03-05
 

--- a/test/fixtures/cdb_dataservices_client/obs_getmeasure.sql
+++ b/test/fixtures/cdb_dataservices_client/obs_getmeasure.sql
@@ -16,10 +16,11 @@ END;
 $$ LANGUAGE plpgsql;
 
 -- Create geomval if it doesn't exist (in postgis 3+ it only exists in postgis_raster)
+-- Uses cdb_dataservices_client.geomval to match the behaviour followed there
 DO $$
 BEGIN
     IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'geomval') THEN
-        CREATE TYPE geomval AS (
+        CREATE TYPE cdb_dataservices_client.geomval AS (
             geom geometry,
             val double precision
         );

--- a/test/fixtures/cdb_dataservices_client/schema.sql
+++ b/test/fixtures/cdb_dataservices_client/schema.sql
@@ -1,1 +1,0 @@
-CREATE SCHEMA IF NOT EXISTS cdb_dataservices_client;


### PR DESCRIPTION
Minor changes in the tests to create the geomval type, if necessary, in the cdb_dataservices_client schema. This is done to match the behaviour of that extension.

No need to deploy, this only changes tests and I did it to make sure that we are testing the same behaviour as the one that, in the end, was implemented in the dataservices extension.