### PR TITLE
[sc138209] Fix column names for Merge analyses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.67.4
+Release 2021-12-28
+
+- Fixes:
+  - Use node ID as buster for alias names on Merge analyses to avoid cache issues
+
 ## 0.67.3
 Release 2021-02-15
 

--- a/lib/node/nodes/merge.js
+++ b/lib/node/nodes/merge.js
@@ -4,7 +4,6 @@ var dot = require('dot');
 dot.templateSettings.strip = false;
 
 var debug = require('../../util/debug')('analysis:merge');
-var utilId = require('../../util/id');
 var Node = require('../node');
 
 var TYPE = 'merge';
@@ -30,7 +29,7 @@ var JOIN_OPERATIONS = {
 };
 
 Merge.prototype.sql = function () {
-    var buster = this.cachedNodeId().slice(0,10);
+    var buster = this.cachedNodeId().slice(0, 10);
 
     var leftAlias = '_cdb_analysis_left_source_' + buster;
     var rightAlias = '_cdb_analysis_right_source_' + buster;

--- a/lib/node/nodes/merge.js
+++ b/lib/node/nodes/merge.js
@@ -30,10 +30,10 @@ var JOIN_OPERATIONS = {
 };
 
 Merge.prototype.sql = function () {
-    var buster = utilId.buster();
+    var buster = this.cachedNodeId().slice(0,10);
 
-    var leftAlias = '_cdb_analysis_left_source' + buster;
-    var rightAlias = '_cdb_analysis_right_source' + buster;
+    var leftAlias = '_cdb_analysis_left_source_' + buster;
+    var rightAlias = '_cdb_analysis_right_source_' + buster;
 
     var columns = this._getColumns(leftAlias, rightAlias);
 

--- a/lib/util/id.js
+++ b/lib/util/id.js
@@ -5,8 +5,3 @@ var crypto = require('crypto');
 module.exports.id = function (content) {
     return crypto.createHash('sha1').update(JSON.stringify(content)).digest('hex');
 };
-
-module.exports.buster = function () {
-    var hrTime = process.hrtime();
-    return hrTime[0] * 1000000 + Math.round(hrTime[1] / 1000);
-};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "camshaft",
-  "version": "0.67.3",
+  "version": "0.67.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "camshaft",
-  "version": "0.67.3",
+  "version": "0.67.4",
   "description": "Analysis library to create data views from queries",
   "keywords": [
     "cartodb",


### PR DESCRIPTION
### Resources

- [Shortcut story](https://app.shortcut.com/cartoteam/story/138209/elmundodata-click-popup-not-showing-info)

### Context

- In https://github.com/CartoDB/camshaft/pull/355/, was added support for `Merge` chained analyses: `_cdb_analysis_left_source`/`_cdb_analysis_right_source` was being used as query alias. This is ok if there is only one `Merge` analysis, but if you add two analyses of this type to the same layer, a name conflict appears in the SQL query. To solve that, a `buster` was added at the end of every alias, just a numeric code generated using the current timestamp.
- This timestamp worked to allow chained analyses, but this causes the query to change every time the map is instantiated, generating cache issues, as described [here](https://app.shortcut.com/cartoteam/story/138209/elmundodata-click-popup-not-showing-info#activity-141539). So, we need each analysis with unique alias names, but this code shouldn't change every time the map is rendered.

### Changes

- Use analysis node ID as `buster` instead of current time.